### PR TITLE
Remove bbtree if not compiling using WITH_EXTRAS

### DIFF
--- a/similarity_search/include/factory/init_methods.h
+++ b/similarity_search/include/factory/init_methods.h
@@ -59,8 +59,10 @@ inline void initMethods() {
   REGISTER_METHOD_CREATOR(int,    METH_DUMMY, CreateDummy)
   
   // bbtree
+#if WITH_EXTRAS
   REGISTER_METHOD_CREATOR(float,  METH_BBTREE, CreateBBTree)
   REGISTER_METHOD_CREATOR(double, METH_BBTREE, CreateBBTree)
+#endif
 
   // ghtree
   REGISTER_METHOD_CREATOR(float,  METH_GHTREE, CreateGHTree)

--- a/similarity_search/include/factory/method/bbtree.h
+++ b/similarity_search/include/factory/method/bbtree.h
@@ -15,6 +15,8 @@
 #ifndef _FACTORY_BBTREE_H_
 #define _FACTORY_BBTREE_H_
 
+#if WITH_EXTRAS
+
 #include <method/bbtree.h>
 
 namespace similarity {
@@ -37,5 +39,7 @@ Index<dist_t>* CreateBBTree(bool PrintProgress,
  */
 
 }
+
+#endif
 
 #endif

--- a/similarity_search/include/method/bbtree.h
+++ b/similarity_search/include/method/bbtree.h
@@ -33,6 +33,8 @@
 #ifndef _BBTREE_H_
 #define _BBTREE_H_
 
+#if WITH_EXTRAS
+
 #include "index.h"
 #include "params.h"
 
@@ -125,5 +127,7 @@ class BBTree : public Index<dist_t> {
 };
 
 }  // namespace similarity
+
+#endif
 
 #endif       // _BBTREE_H_

--- a/similarity_search/src/CMakeLists.txt
+++ b/similarity_search/src/CMakeLists.txt
@@ -15,6 +15,7 @@ file(GLOB SRC_FILES ${PROJECT_SOURCE_DIR}/src/*.cc ${PROJECT_SOURCE_DIR}/src/spa
 
 if (NOT WITH_EXTRAS)
   # Extra methods
+  list(REMOVE_ITEM SRC_FILES ${PROJECT_SOURCE_DIR}/src/method/bbtree.cc)
   list(REMOVE_ITEM SRC_FILES ${PROJECT_SOURCE_DIR}/src/method/lsh.cc)
   list(REMOVE_ITEM SRC_FILES ${PROJECT_SOURCE_DIR}/src/method/lsh_multiprobe.cc)
   list(REMOVE_ITEM SRC_FILES ${PROJECT_SOURCE_DIR}/src/method/lsh_space.cc)


### PR DESCRIPTION
* bbtree is licensed under GPL and will virally
cause this whole project to be under GPL if included
in the normal way