### PR TITLE
Don't write out debug messages on shutdown

### DIFF
--- a/python_bindings/nmslib.cc
+++ b/python_bindings/nmslib.cc
@@ -412,10 +412,12 @@ class PythonLogger
           inner.attr("critical")(message);
           break;
       }
-    } catch (const std::exception & e) {
-      std::cerr << "Failed to log '" << message << "'. Exception:" << e.what() << std::endl;
     } catch (...) {
-      std::cerr << "Failed to log '" << message << "'" << std::endl;
+      // This is almost certainly due to python process shut down.
+      // Just write the message out to stderr if its not a debug message
+      if (severity != LIB_DEBUG) {
+        StdErrLogger().log(severity, file, line, function, message);
+      }
     }
   }
 };


### PR DESCRIPTION
When the python intrpreter exits, any attempts to log messages into it throw an exception.
Rather than writing these spurious error messages out, just write out the log message
using the default stderrlogger (if it's not a debug message).