### PR TITLE
various windows build fixes

### DIFF
--- a/python_bindings/setup.py
+++ b/python_bindings/setup.py
@@ -7,6 +7,11 @@ import setuptools
 __version__ = '1.7.3.4'
 
 libdir = os.path.join(".", "nmslib", "similarity_search")
+if not os.path.isdir(libdir) and sys.platform.startswith("win"):
+    # If the nmslib symlink doesn't work (windows symlink support w/ git is
+    # a little iffy), fallback to use a relative path
+    libdir = os.path.join("..", "similarity_search")
+
 library_file = os.path.join(libdir, "release", "libNonMetricSpaceLib.a")
 source_files = ['nmslib.cc']
 
@@ -22,7 +27,7 @@ else:
     exclude_files = set("""bbtree.cc lsh.cc lsh_multiprobe.cc lsh_space.cc falconn.cc nndes.cc space_sqfd.cc
                         dummy_app.cc main.cc""".split())
 
-    for root, subdirs, files in os.walk(os.path.join("nmslib", "similarity_search", "src")):
+    for root, subdirs, files in os.walk(os.path.join(libdir, "src")):
         source_files.extend(os.path.join(root, f) for f in files
                             if f.endswith(".cc") and f not in exclude_files)
 

--- a/similarity_search/src/method/hnsw.cc
+++ b/similarity_search/src/method/hnsw.cc
@@ -684,7 +684,7 @@ namespace similarity {
     void
     Hnsw<dist_t>::Search(KNNQuery<dist_t> *query, IdType) const
     {
-        if (this->data_.empty() and this->data_rearranged_.empty()) {
+        if (this->data_.empty() && this->data_rearranged_.empty()) {
           return;
         }
         bool useOld = searchAlgoType_ == kOld || (searchAlgoType_ == kHybrid && ef_ >= 1000);

--- a/similarity_search/src/method/small_world_rand.cc
+++ b/similarity_search/src/method/small_world_rand.cc
@@ -18,6 +18,10 @@
 // This is only for _mm_prefetch
 #include <mmintrin.h>
 
+#if defined(_WIN32) || defined(WIN32)
+#include <intrin.h>
+#endif
+
 #include "portable_simd.h"
 #include "space.h"
 #include "knnquery.h"

--- a/similarity_search/src/method/vptree.cc
+++ b/similarity_search/src/method/vptree.cc
@@ -21,6 +21,9 @@
 
 // This is only for _mm_prefetch
 #include <mmintrin.h>
+#if defined(_WIN32) || defined(WIN32)
+#include <intrin.h>
+#endif
 
 #include "portable_simd.h"
 #include "space.h"


### PR DESCRIPTION
'and' isn't a valid operator on C++ (though apparently works in linux), and
on some windows configurations we needed to include a different header file for
_mm_prefetch. Also if git wasn't configured with symlinks succesfully, fallback to a relative
path in setup.py.

Fixes https://github.com/nmslib/nmslib/issues/295 and https://github.com/nmslib/nmslib/issues/348