### PR TITLE
Bugfixes for small_world_rand batch addition/deletion and index loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ NMSLIB is an **extendible library**, which means that is possible to add new sea
 
 Other contributors:  Lawrence Cayton, Wei Dong, Avrelin Nikita, Dmitry Yashunin, Bob Poekert, @orgoro, Maxim Andreev, Daniel Lemire, Nathan Kurz, Alexander Ponomarenko.
 
-**Citing:** If you find this library useful, feel free to cite our SISAP paper [**[BibTex]**](http://dblp.uni-trier.de/rec/bibtex/conf/sisap/BoytsovN13) as well as other papers listed in the end. One crucial contribution to cite is the fast Hierarchical Navigable World graph (HNSW) method [**[BibTex]**](https://dblp.uni-trier.de/rec/bibtex/journals/corr/MalkovY16).
+**Citing:** If you find this library useful, feel free to cite our SISAP paper [**[BibTex]**](http://dblp.uni-trier.de/rec/bibtex/conf/sisap/BoytsovN13) as well as other papers listed in the end. One crucial contribution to cite is the fast Hierarchical Navigable World graph (HNSW) method [**[BibTex]**](https://dblp.uni-trier.de/rec/bibtex/journals/corr/MalkovY16). Please, [also check out the stand-alone HNSW implementation by Yury Malkov](https://github.com/nmslib/hnswlib).
 
 Leo(nid) Boytsov is a maintainer. Leo was supported by the [Open Advancement of Question Answering Systems (OAQA) group](https://github.com/oaqa) and the following NSF grant #1618159: "[Matching and Ranking via Proximity Graphs: Applications to Question Answering and Beyond](https://www.nsf.gov/awardsearch/showAward?AWD_ID=1618159&HistoricalAwards=false)". Bileg was supported by the [iAd Center](https://web.archive.org/web/20160306011711/http://www.iad-center.com/).
 

--- a/similarity_search/include/method/small_world_rand.h
+++ b/similarity_search/include/method/small_world_rand.h
@@ -274,6 +274,11 @@ public:
   void SetQueryTimeParams(const AnyParams& ) override;
 
   enum PatchingStrategy { kNone = 0, kNeighborsOnly = 1 };
+
+  //This method should be called before LoadIndex to initialize parameters,
+  //that are usually initialized in Create Index
+  void InitParamsManually(const AnyParams& IndexParams);
+
 private:
 
   size_t                NN_;

--- a/test_batch_app/test_batch_mod.cc
+++ b/test_batch_app/test_batch_mod.cc
@@ -194,10 +194,12 @@ void doWork(int argc, char* argv[]) {
 
   CHECK_MSG(knnK > 0, "k-NN k should be > 0!");
 
+  int seed = 0;
+
   if (LogFile != "") 
-    initLibrary(LIB_LOGFILE, LogFile.c_str());
+    initLibrary(seed, LIB_LOGFILE, LogFile.c_str());
   else
-    initLibrary(LIB_LOGSTDERR, NULL); // Use STDERR for logging
+    initLibrary(seed, LIB_LOGSTDERR, NULL); // Use STDERR for logging
 
   unique_ptr<Space<float>>  space(SpaceFactoryRegistry<float>::Instance().CreateSpace(SpaceType, *SpaceParams));
 


### PR DESCRIPTION
This pull request fixes some bugs discussed in the issue https://github.com/nmslib/nmslib/issues/351

There are three bugfixes:
1) AddBatch checks if index is not empty. If so, it creates new neighbourless node, otherwise it adds elements in already created index.
2) DeleteBatch does not create any threads if indexThreadQty_==1.
3) Parameters initialization before index loading (method InitParamsManually).
4) Legacy test_batch_app library initialization (initLibrary) updated.