### PR TITLE
Don't set -march=native if -march is set in CFLAGS

### DIFF
--- a/python_bindings/setup.py
+++ b/python_bindings/setup.py
@@ -84,8 +84,10 @@ class BuildExt(build_ext):
     """A custom build extension for adding compiler-specific options."""
     c_opts = {
         'msvc': ['/EHsc', '/openmp', '/O2'],
-        'unix': ['-O3', '-march=native'],
+        'unix': ['-O3'],
     }
+    if 'CFLAGS' not in os.environ or "-march" not in os.environ["CFLAGS"]:
+        c_opts['unix'].append('-march=native')
     link_opts = {
         'unix': [],
         'msvc': [],


### PR DESCRIPTION
This gives a workaround for cases where the library is built on one CPU, then attempts to run on an older one and fails due to illegal instructions. (frequently seen when deploying via docker). I've implemented the fix suggested in #325.

Resolves #325