### PR TITLE
require pybind11>=2.2.3

### DIFF
--- a/python_bindings/requirements.txt
+++ b/python_bindings/requirements.txt
@@ -1,2 +1,2 @@
 numpy>=1.10.0
-pybind11>=2.0
+pybind11>=2.2.3


### PR DESCRIPTION
Looks like pybind fixed the issue https://github.com/nmslib/nmslib/issues/307 with older versions of pip, see this PR: https://github.com/pybind/pybind11/pull/1190



Upgrading to a newer version might help ease some installs.