### PR TITLE
Fixed typo (envrion to environ) in `setup.py`. Issue number 408.

### DIFF
--- a/python_bindings/setup.py
+++ b/python_bindings/setup.py
@@ -106,7 +106,7 @@ class BuildExt(build_ext):
     if 'ARCH' in os.environ:
         # /arch:[IA32|SSE|SSE2|AVX|AVX2|ARMv7VE|VFPv4]
         # See https://docs.microsoft.com/en-us/cpp/build/reference/arch-x86
-        c_opts['msvc'].append("/arch:{}".format(os.envrion['ARCH']))
+        c_opts['msvc'].append("/arch:{}".format(os.environ['ARCH']))  # bugfix
     if 'CFLAGS' not in os.environ or "-march" not in os.environ["CFLAGS"]:
         c_opts['unix'].append('-march=native')
     link_opts = {


### PR DESCRIPTION
Hi nmslib community,

I have fixed bug #408 in the branch named '408' in my fork. This small typo impacted arch flavors of Linux, preventing us from using nmslib on our scientific computing cluster. Thank you for your work,

Brendan``