### PR TITLE
Fix call order for index.setQueryTimeParams() in test_hnsw_recall example

### DIFF
--- a/python_bindings/notebooks/test_hnsw_recall.py
+++ b/python_bindings/notebooks/test_hnsw_recall.py
@@ -27,6 +27,10 @@ def testHnswRecallL2(dataMatrix, queryMatrix, k, M=30, efC=200, efS=1000, numThr
   end = time.time() 
   print('Indexing time = %f' % (end-start))
 
+  # Setting query-time parameters
+  queryTimeParams = {'efSearch': efS}
+  print('Setting query-time parameters', queryTimeParams)
+  index.setQueryTimeParams(queryTimeParams)
 
   # Querying
   start = time.time()
@@ -51,11 +55,6 @@ def testHnswRecallL2(dataMatrix, queryMatrix, k, M=30, efC=200, efS=1000, numThr
 
   print('brute-force kNN time total=%f (sec), per query=%f (sec)' % 
        (end-start, float(end-start)/queryQty) )
-
-  # Setting query-time parameters
-  queryTimeParams = {'efSearch': efS}
-  print('Setting query-time parameters', queryTimeParams)
-  index.setQueryTimeParams(queryTimeParams)
 
   # Finally computing recall for every i-th neighbor
   for n in range(k):


### PR DESCRIPTION
I happened to find and use this example script to bootstrap code for some recall testing I was doing. I noticed that index.setQueryTimeParams() was being applied after running the KNN queries, which was causing efS to be ignored and queries would use the library default instead (which I think is 20). The script is trying to set efS to 200 which makes the recall test results look worse than they should.

Before:
```
jschmitz28:~$ python test_hnsw_recall.py

Index-time parameters {'M': 30, 'indexThreadQty': 4, 'efConstruction': 200, 'post': 0}
Indexing time = 14.957313
kNN time total=0.028158 (sec), per query=0.000028 (sec), per query adjusted for thread number=0.000113 (sec)
Computing gold-standard data
Brute-force preparation time 0.007581
brute-force kNN time total=2.261873 (sec), per query=0.002262 (sec)
Setting query-time parameters {'efSearch': 200}
kNN recall for neighbor 1 0.998000
kNN recall for neighbor 2 0.998000
kNN recall for neighbor 3 0.998000
kNN recall for neighbor 4 0.996000
kNN recall for neighbor 5 0.996000
kNN recall for neighbor 6 0.994000
kNN recall for neighbor 7 0.988000
kNN recall for neighbor 8 0.953000
kNN recall for neighbor 9 0.847000
kNN recall for neighbor 10 0.590000
Index-time parameters {'M': 30, 'indexThreadQty': 4, 'efConstruction': 200, 'post': 0}
Indexing time = 37.621784
kNN time total=0.030850 (sec), per query=0.000031 (sec), per query adjusted for thread number=0.000123 (sec)
Computing gold-standard data
Brute-force preparation time 0.007493
brute-force kNN time total=2.077078 (sec), per query=0.002077 (sec)
Setting query-time parameters {'efSearch': 200}
kNN recall for neighbor 1 0.995000
kNN recall for neighbor 2 0.965000
kNN recall for neighbor 3 0.930000
kNN recall for neighbor 4 0.877000
kNN recall for neighbor 5 0.834000
kNN recall for neighbor 6 0.763000
kNN recall for neighbor 7 0.654000
kNN recall for neighbor 8 0.504000
kNN recall for neighbor 9 0.342000
kNN recall for neighbor 10 0.123000
```

After:
```
jschmitz28:~$ python test_hnsw_recall.py

Index-time parameters {'M': 30, 'indexThreadQty': 4, 'efConstruction': 200, 'post': 0}
Indexing time = 14.701650
Setting query-time parameters {'efSearch': 200}
kNN time total=0.190982 (sec), per query=0.000191 (sec), per query adjusted for thread number=0.000764 (sec)
Computing gold-standard data
Brute-force preparation time 0.007607
brute-force kNN time total=2.265778 (sec), per query=0.002266 (sec)
kNN recall for neighbor 1 1.000000
kNN recall for neighbor 2 1.000000
kNN recall for neighbor 3 1.000000
kNN recall for neighbor 4 1.000000
kNN recall for neighbor 5 1.000000
kNN recall for neighbor 6 1.000000
kNN recall for neighbor 7 1.000000
kNN recall for neighbor 8 1.000000
kNN recall for neighbor 9 1.000000
kNN recall for neighbor 10 0.994000
Index-time parameters {'M': 30, 'indexThreadQty': 4, 'efConstruction': 200, 'post': 0}
Indexing time = 39.090262
Setting query-time parameters {'efSearch': 200}
kNN time total=0.256426 (sec), per query=0.000256 (sec), per query adjusted for thread number=0.001026 (sec)
Computing gold-standard data
Brute-force preparation time 0.007590
brute-force kNN time total=2.242196 (sec), per query=0.002242 (sec)
kNN recall for neighbor 1 1.000000
kNN recall for neighbor 2 1.000000
kNN recall for neighbor 3 1.000000
kNN recall for neighbor 4 1.000000
kNN recall for neighbor 5 1.000000
kNN recall for neighbor 6 1.000000
kNN recall for neighbor 7 0.999000
kNN recall for neighbor 8 0.975000
kNN recall for neighbor 9 0.891000
kNN recall for neighbor 10 0.636000
```