### PR TITLE
Use conditional numpy dependencies for Python 2/3

### DIFF
--- a/python_bindings/setup.py
+++ b/python_bindings/setup.py
@@ -5,7 +5,7 @@ import sys
 import setuptools
 import struct
 
-__version__ = '2.0.6'
+__version__ = '2.0.7'
 
 if sys.platform.startswith("win") and struct.calcsize("P") * 8 == 32:
     raise RuntimeError("Windows 32-bit is not supported.")

--- a/python_bindings/setup.py
+++ b/python_bindings/setup.py
@@ -11,16 +11,14 @@ if sys.platform.startswith("win") and struct.calcsize("P") * 8 == 32:
     raise RuntimeError("Windows 32-bit is not supported.")
 
 dep_list = ['pybind11>=2.2.3', 'psutil']
+dep_list.append("numpy>=1.10.0,<1.17 ; python_version='2.7'")
+dep_list.append("numpy>=1.10.0 ; python_version>='3.5'")
+
 py_version = tuple([int(v) for v in sys.version.split('.')[:2]])
-if py_version == (2, 7):
-    dep_list.append('numpy>=1.10.0,<1.17')
-elif py_version < (3, 5):
+if py_version != (2, 7) and py_version < (3, 5):
     raise RuntimeError("Python version 2.7 or >=3.5 required.")
-else:
-    dep_list.append('numpy>=1.10.0')
 
 print('Dependence list:', dep_list)
-
 
 libdir = os.path.join(".", "similarity_search")
 if not os.path.isdir(libdir) and sys.platform.startswith("win"):

--- a/python_bindings/setup.py
+++ b/python_bindings/setup.py
@@ -11,7 +11,7 @@ if sys.platform.startswith("win") and struct.calcsize("P") * 8 == 32:
     raise RuntimeError("Windows 32-bit is not supported.")
 
 dep_list = ['pybind11>=2.2.3', 'psutil']
-dep_list.append("numpy>=1.10.0,<1.17 ; python_version='2.7'")
+dep_list.append("numpy>=1.10.0,<1.17 ; python_version=='2.7'")
 dep_list.append("numpy>=1.10.0 ; python_version>='3.5'")
 
 py_version = tuple([int(v) for v in sys.version.split('.')[:2]])

--- a/python_bindings/setup.py
+++ b/python_bindings/setup.py
@@ -5,7 +5,7 @@ import sys
 import setuptools
 import struct
 
-__version__ = '2.0.7'
+__version__ = '2.0.6'
 
 if sys.platform.startswith("win") and struct.calcsize("P") * 8 == 32:
     raise RuntimeError("Windows 32-bit is not supported.")


### PR DESCRIPTION
Fixes downgrades under Python 3

`poetry` uses the information in the pypi json API at https://pypi.org/pypi/nmslib/json to decide that nmslib requires nmslib < 1.17.

`requires_dist` currently comes out as 
```
    "requires_dist": [
      "pybind11 (>=2.2.3)",
      "psutil",
      "numpy (<1.17,>=1.10.0)"
    ],
```

which causes poetry to downgrade numpy even for Python 3, which in my case forces a downgrade of another package, which results in dependency resolution failing.

This change should prevent it specifying numpy<1.17 for Python 3.

Will now come out as
```
    "requires_dist": [
      "pybind11 (>=2.2.3)",
      "psutil",
      "numpy (<1.17,>=1.10.0) ; python_version=='2.7'"
      "numpy (>=1.10.0) ; python_version>='3.5'"
    ],
```

Hopefully doesn't break anything I don't know about...