### PR TITLE
Add ARM compatibility

### DIFF
--- a/similarity_search/include/method/hnsw_distfunc_opt_impl_inline.h
+++ b/similarity_search/include/method/hnsw_distfunc_opt_impl_inline.h
@@ -36,102 +36,52 @@ namespace similarity {
 // is 8 floats
 #define TMP_RES_ARRAY(varName)  float PORTABLE_ALIGN32 (varName)[8];
 
-inline float
-L2Sqr16ExtSSE(const float *pVect1, const float *pVect2, size_t &qty, float * __restrict TmpRes) {
 #ifdef PORTABLE_SSE2
-  // size_t qty4 = qty >> 2;
+
+inline float L2Sqr16Ext(const float *pVect1, const float *pVect2, size_t &qty, float *__restrict TmpRes) {
   size_t qty16 = qty >> 4;
 
   const float *pEnd1 = pVect1 + (qty16 << 4);
-  // const float* pEnd2 = pVect1 + (qty4 << 2);
-  // const float* pEnd3 = pVect1 + qty;
 
-  __m128 diff, v1, v2;
-  __m128 sum = _mm_set1_ps(0);
-
+  __m128 diff, v1_32_4, v2_32_4;
+  __m128 sum_32_4 = _mm_set1_ps(0);
   while (pVect1 < pEnd1) {
-    //_mm_prefetch((char*)(pVect2 + 16), _MM_HINT_T0);
-    v1 = _mm_loadu_ps(pVect1);
+    PREFETCH((char *) (pVect2 + 16), _MM_HINT_T0);
+    v1_32_4 = _mm_loadu_ps(pVect1);
     pVect1 += 4;
-    v2 = _mm_loadu_ps(pVect2);
+    v2_32_4 = _mm_loadu_ps(pVect2);
     pVect2 += 4;
-    diff = _mm_sub_ps(v1, v2);
-    sum = _mm_add_ps(sum, _mm_mul_ps(diff, diff));
+    diff = _mm_sub_ps(v1_32_4, v2_32_4);
+    sum_32_4 = _mm_add_ps(sum_32_4, _mm_mul_ps(diff, diff));
 
-    v1 = _mm_loadu_ps(pVect1);
+    v1_32_4 = _mm_loadu_ps(pVect1);
     pVect1 += 4;
-    v2 = _mm_loadu_ps(pVect2);
+    v2_32_4 = _mm_loadu_ps(pVect2);
     pVect2 += 4;
-    diff = _mm_sub_ps(v1, v2);
-    sum = _mm_add_ps(sum, _mm_mul_ps(diff, diff));
+    diff = _mm_sub_ps(v1_32_4, v2_32_4);
+    sum_32_4 = _mm_add_ps(sum_32_4, _mm_mul_ps(diff, diff));
 
-    v1 = _mm_loadu_ps(pVect1);
+    v1_32_4 = _mm_loadu_ps(pVect1);
     pVect1 += 4;
-    v2 = _mm_loadu_ps(pVect2);
+    v2_32_4 = _mm_loadu_ps(pVect2);
     pVect2 += 4;
-    diff = _mm_sub_ps(v1, v2);
-    sum = _mm_add_ps(sum, _mm_mul_ps(diff, diff));
+    diff = _mm_sub_ps(v1_32_4, v2_32_4);
+    sum_32_4 = _mm_add_ps(sum_32_4, _mm_mul_ps(diff, diff));
 
-    v1 = _mm_loadu_ps(pVect1);
+    v1_32_4 = _mm_loadu_ps(pVect1);
     pVect1 += 4;
-    v2 = _mm_loadu_ps(pVect2);
+    v2_32_4 = _mm_loadu_ps(pVect2);
     pVect2 += 4;
-    diff = _mm_sub_ps(v1, v2);
-    sum = _mm_add_ps(sum, _mm_mul_ps(diff, diff));
+    diff = _mm_sub_ps(v1_32_4, v2_32_4);
+    sum_32_4 = _mm_add_ps(sum_32_4, _mm_mul_ps(diff, diff));
   }
 
-  _mm_store_ps(TmpRes, sum);
-  float res = TmpRes[0] + TmpRes[1] + TmpRes[2] + TmpRes[3];
+  _mm_store_ps(TmpRes, sum_32_4);
 
-  return (res);
-#else
-  #pragma message WARN("L2Sqr16ExtSSE: SSE2 is not available")
-  v = L2NormStandard(pVect1, pVect2, qty);
-  return v * v;
-#endif
+  return TmpRes[0] + TmpRes[1] + TmpRes[2] + TmpRes[3];
 }
 
-inline float
-L2Sqr16ExtAVX(const float *pVect1, const float *pVect2, size_t &qty, float * __restrict TmpRes) {
-#ifdef PORTABLE_AVX
-  size_t qty16 = qty >> 4;
-
-  const float *pEnd1 = pVect1 + (qty16 << 4);
-
-  __m256 diff, v1, v2;
-  __m256 sum = _mm256_set1_ps(0);
-
-  while (pVect1 < pEnd1) {
-    //_mm_prefetch((char*)(pVect2 + 16), _MM_HINT_T0);
-    v1 = _mm256_loadu_ps(pVect1);
-    pVect1 += 8;
-    v2 = _mm256_loadu_ps(pVect2);
-    pVect2 += 8;
-    diff = _mm256_sub_ps(v1, v2);
-    sum = _mm256_add_ps(sum, _mm256_mul_ps(diff, diff));
-
-    v1 = _mm256_loadu_ps(pVect1);
-    pVect1 += 8;
-    v2 = _mm256_loadu_ps(pVect2);
-    pVect2 += 8;
-    diff = _mm256_sub_ps(v1, v2);
-    sum = _mm256_add_ps(sum, _mm256_mul_ps(diff, diff));
-  }
-
-  _mm256_store_ps(TmpRes, sum);
-  float res = TmpRes[0] + TmpRes[1] + TmpRes[2] + TmpRes[3] + TmpRes[4] + TmpRes[5] + TmpRes[6] + TmpRes[7];
-
-  return (res);
-#else
-  #pragma message WARN("L2Sqr16Ext: AVX is not available")
-  return L2Sqr16ExtSSE(pVect1, pVect2, qty, TmpRes);
-#endif
-};
-
-
-inline float
-L2SqrExtSSE(const float *pVect1, const float *pVect2, size_t &qty, float * __restrict TmpRes) {
-#ifdef PORTABLE_SSE2
+inline float L2SqrExt(const float *pVect1, const float *pVect2, size_t &qty, float *__restrict TmpRes) {
   size_t qty4 = qty >> 2;
   size_t qty16 = qty >> 4;
 
@@ -139,179 +89,429 @@ L2SqrExtSSE(const float *pVect1, const float *pVect2, size_t &qty, float * __res
   const float *pEnd2 = pVect1 + (qty4 << 2);
   const float *pEnd3 = pVect1 + qty;
 
-  __m128 diff, v1, v2;
-  __m128 sum = _mm_set1_ps(0);
+  __m128 diff, v1_32_4, v2_32_4;
+  __m128 sum_32_4 = _mm_set1_ps(0);
 
   while (pVect1 < pEnd1) {
-    //_mm_prefetch((char*)(pVect2 + 16), _MM_HINT_T0);
-    v1 = _mm_loadu_ps(pVect1);
+    PREFETCH((char *) (pVect2 + 16), _MM_HINT_T0);
+    v1_32_4 = _mm_loadu_ps(pVect1);
     pVect1 += 4;
-    v2 = _mm_loadu_ps(pVect2);
+    v2_32_4 = _mm_loadu_ps(pVect2);
     pVect2 += 4;
-    diff = _mm_sub_ps(v1, v2);
-    sum = _mm_add_ps(sum, _mm_mul_ps(diff, diff));
+    diff = _mm_sub_ps(v1_32_4, v2_32_4);
+    sum_32_4 = _mm_add_ps(sum_32_4, _mm_mul_ps(diff, diff));
 
-    v1 = _mm_loadu_ps(pVect1);
+    v1_32_4 = _mm_loadu_ps(pVect1);
     pVect1 += 4;
-    v2 = _mm_loadu_ps(pVect2);
+    v2_32_4 = _mm_loadu_ps(pVect2);
     pVect2 += 4;
-    diff = _mm_sub_ps(v1, v2);
-    sum = _mm_add_ps(sum, _mm_mul_ps(diff, diff));
+    diff = _mm_sub_ps(v1_32_4, v2_32_4);
+    sum_32_4 = _mm_add_ps(sum_32_4, _mm_mul_ps(diff, diff));
 
-    v1 = _mm_loadu_ps(pVect1);
+    v1_32_4 = _mm_loadu_ps(pVect1);
     pVect1 += 4;
-    v2 = _mm_loadu_ps(pVect2);
+    v2_32_4 = _mm_loadu_ps(pVect2);
     pVect2 += 4;
-    diff = _mm_sub_ps(v1, v2);
-    sum = _mm_add_ps(sum, _mm_mul_ps(diff, diff));
+    diff = _mm_sub_ps(v1_32_4, v2_32_4);
+    sum_32_4 = _mm_add_ps(sum_32_4, _mm_mul_ps(diff, diff));
 
-    v1 = _mm_loadu_ps(pVect1);
+    v1_32_4 = _mm_loadu_ps(pVect1);
     pVect1 += 4;
-    v2 = _mm_loadu_ps(pVect2);
+    v2_32_4 = _mm_loadu_ps(pVect2);
     pVect2 += 4;
-    diff = _mm_sub_ps(v1, v2);
-    sum = _mm_add_ps(sum, _mm_mul_ps(diff, diff));
+    diff = _mm_sub_ps(v1_32_4, v2_32_4);
+    sum_32_4 = _mm_add_ps(sum_32_4, _mm_mul_ps(diff, diff));
   }
 
   while (pVect1 < pEnd2) {
-    v1 = _mm_loadu_ps(pVect1);
+    v1_32_4 = _mm_loadu_ps(pVect1);
     pVect1 += 4;
-    v2 = _mm_loadu_ps(pVect2);
+    v2_32_4 = _mm_loadu_ps(pVect2);
     pVect2 += 4;
-    diff = _mm_sub_ps(v1, v2);
-    sum = _mm_add_ps(sum, _mm_mul_ps(diff, diff));
+    diff = _mm_sub_ps(v1_32_4, v2_32_4);
+    sum_32_4 = _mm_add_ps(sum_32_4, _mm_mul_ps(diff, diff));
   }
 
-  _mm_store_ps(TmpRes, sum);
-  float res = TmpRes[0] + TmpRes[1] + TmpRes[2] + TmpRes[3];
+  _mm_store_ps(TmpRes, sum_32_4);
+  float sum_32_1 = TmpRes[0] + TmpRes[1] + TmpRes[2] + TmpRes[3];
+  float diff_32_1;
+  while (pVect1 < pEnd3) {
+      diff_32_1 = *pVect1++ - *pVect2++;
+      sum_32_1 += diff_32_1 * diff_32_1;
+  }
+
+  return sum_32_1;
+}
+
+inline float ScalarProduct(const float *__restrict pVect1, const float *__restrict pVect2, size_t qty,
+                  float *__restrict TmpRes) {
+  size_t qty16 = qty / 16;
+  size_t qty4 = qty / 4;
+
+  const float *pEnd1 = pVect1 + 16 * qty16;
+  const float *pEnd2 = pVect1 + 4 * qty4;
+  const float *pEnd3 = pVect1 + qty;
+
+  __m128 v1_32_4, v2_32_4;
+  __m128 sum_32_4 = _mm_set1_ps(0);
+
+  while (pVect1 < pEnd1) {
+    v1_32_4 = _mm_loadu_ps(pVect1);
+    pVect1 += 4;
+    v2_32_4 = _mm_loadu_ps(pVect2);
+    pVect2 += 4;
+    sum_32_4 = _mm_add_ps(sum_32_4, _mm_mul_ps(v1_32_4, v2_32_4));
+
+    v1_32_4 = _mm_loadu_ps(pVect1);
+    pVect1 += 4;
+    v2_32_4 = _mm_loadu_ps(pVect2);
+    pVect2 += 4;
+    sum_32_4 = _mm_add_ps(sum_32_4, _mm_mul_ps(v1_32_4, v2_32_4));
+
+    v1_32_4 = _mm_loadu_ps(pVect1);
+    pVect1 += 4;
+    v2_32_4 = _mm_loadu_ps(pVect2);
+    pVect2 += 4;
+    sum_32_4 = _mm_add_ps(sum_32_4, _mm_mul_ps(v1_32_4, v2_32_4));
+
+    v1_32_4 = _mm_loadu_ps(pVect1);
+    pVect1 += 4;
+    v2_32_4 = _mm_loadu_ps(pVect2);
+    pVect2 += 4;
+    sum_32_4 = _mm_add_ps(sum_32_4, _mm_mul_ps(v1_32_4, v2_32_4));
+  }
+
+  while (pVect1 < pEnd2) {
+    v1_32_4 = _mm_loadu_ps(pVect1);
+    pVect1 += 4;
+    v2_32_4 = _mm_loadu_ps(pVect2);
+    pVect2 += 4;
+    sum_32_4 = _mm_add_ps(sum_32_4, _mm_mul_ps(v1_32_4, v2_32_4));
+  }
+
+  _mm_store_ps(TmpRes, sum_32_4);
+  float sum_32_1 = TmpRes[0] + TmpRes[1] + TmpRes[2] + TmpRes[3];
+  while (pVect1 < pEnd3) {
+    sum_32_1 += (*pVect1) * (*pVect2);
+    ++pVect1;
+    ++pVect2;
+  }
+  return sum_32_1;
+}
+
+#elif defined(PORTABLE_AVX)
+
+inline float L2Sqr16Ext(const float *pVect1, const float *pVect2, size_t &qty, float * __restrict TmpRes) {
+  size_t qty16 = qty >> 4;
+
+  const float *pEnd1 = pVect1 + (qty16 << 4);
+
+  __m256 diff_32_8, v1_32_8, v2_32_8;
+  __m256 sum_32_8 = _mm256_set1_ps(0);
+
+  while (pVect1 < pEnd1) {
+    PREFETCH((char*)(pVect2 + 16), _MM_HINT_T0);
+    v1_32_8 = _mm256_loadu_ps(pVect1);
+    pVect1 += 8;
+    v2_32_8 = _mm256_loadu_ps(pVect2);
+    pVect2 += 8;
+    diff_32_8 = _mm256_sub_ps(v1_32_8, v2_32_8);
+    sum_32_8 = _mm256_add_ps(sum_32_8, _mm256_mul_ps(diff_32_8, diff_32_8));
+
+    v1_32_8 = _mm256_loadu_ps(pVect1);
+    pVect1 += 8;
+    v2_32_8 = _mm256_loadu_ps(pVect2);
+    pVect2 += 8;
+    diff_32_8 = _mm256_sub_ps(v1_32_8, v2_32_8);
+    sum_32_8 = _mm256_add_ps(sum_32_8, _mm256_mul_ps(diff_32_8, diff_32_8));
+  }
+
+  _mm256_store_ps(TmpRes, sum_32_8);
+  return TmpRes[0] + TmpRes[1] + TmpRes[2] + TmpRes[3] + TmpRes[4] + TmpRes[5] + TmpRes[6] + TmpRes[7];
+}
+
+inline float L2SqrExt(const float *pVect1, const float *pVect2, size_t &qty, float *__restrict TmpRes) {
+  size_t qty4 = qty >> 2;
+  size_t qty16 = qty >> 4;
+
+  const float *pEnd1 = pVect1 + (qty16 << 4);
+  const float *pEnd2 = pVect1 + (qty4 << 2);
+  const float *pEnd3 = pVect1 + qty;
+
+  __m256 diff_32_8, v1_32_8, v2_32_8;
+  __m256 sum_32_8 = _mm256_set1_ps(0);
+
+  while (pVect1 < pEnd1) {
+    PREFETCH((char*)(pVect2 + 16), _MM_HINT_T0);
+    v1_32_8 = _mm256_loadu_ps(pVect1);
+    pVect1 += 8;
+    v2_32_8 = _mm256_loadu_ps(pVect2);
+    pVect2 += 8;
+    diff_32_8 = _mm256_sub_ps(v1_32_8, v2_32_8);
+    sum_32_8 = _mm256_add_ps(sum_32_8, _mm256_mul_ps(diff_32_8, diff_32_8));
+
+    v1_32_8 = _mm256_loadu_ps(pVect1);
+    pVect1 += 8;
+    v2_32_8 = _mm256_loadu_ps(pVect2);
+    pVect2 += 8;
+    diff_32_8 = _mm256_sub_ps(v1_32_8, v2_32_8);
+    sum_32_8 = _mm256_add_ps(sum_32_8, _mm256_mul_ps(diff_32_8, diff_32_8));
+  }
+
+  __m128 diff_32_4, v1_32_4, v2_32_4;
+  __m128 sum_32_4 = _mm_add_ps(_mm256_extractf128_ps(sum_32_8, 0), _mm256_extractf128_ps(sum_32_8, 1));
+
+  while (pVect1 < pEnd2) {
+    v1_32_4 = _mm_loadu_ps(pVect1);
+    pVect1 += 4;
+    v2_32_4 = _mm_loadu_ps(pVect2);
+    pVect2 += 4;
+    diff_32_4 = _mm_sub_ps(v1_32_4, v2_32_4);
+    sum_32_4 = _mm_add_ps(sum_32_4, _mm_mul_ps(diff_32_4, diff_32_4));
+  }
+
+  _mm_store_ps(TmpRes, sum_32_4);
+  float sum_32_1 = TmpRes[0] + TmpRes[1] + TmpRes[2] + TmpRes[3];
+  float diff_32_1;
+  while (pVect1 < pEnd3) {
+    diff_32_1 = *pVect1++ - *pVect2++;
+    sum_32_1 += diff_32_1 * diff_32_1;
+  }
+
+  return sum_32_1;
+}
+
+inline float ScalarProduct(const float *__restrict pVect1, const float *__restrict pVect2, size_t qty,
+                  float *__restrict TmpRes) {
+  size_t qty16 = qty / 16;
+  size_t qty4 = qty / 4;
+
+  const float *pEnd1 = pVect1 + 16 * qty16;
+  const float *pEnd2 = pVect1 + 4 * qty4;
+  const float *pEnd3 = pVect1 + qty;
+
+  __m256 v1_32_8, v2_32_8;
+  __m256 sum_32_8 = _mm256_set1_ps(0);
+
+  while (pVect1 < pEnd1) {
+    PREFETCH((char*)(pVect2 + 16), _MM_HINT_T0);
+
+    v1_32_8 = _mm256_loadu_ps(pVect1);
+    pVect1 += 8;
+    v2_32_8 = _mm256_loadu_ps(pVect2);
+    pVect2 += 8;
+    sum_32_8 = _mm256_add_ps(sum_32_8, _mm256_mul_ps(v1_32_8, v2_32_8));
+
+    v1_32_8 = _mm256_loadu_ps(pVect1);
+    pVect1 += 8;
+    v2_32_8 = _mm256_loadu_ps(pVect2);
+    pVect2 += 8;
+    sum_32_8 = _mm256_add_ps(sum_32_8, _mm256_mul_ps(v1_32_8, v2_32_8));
+  }
+
+  __m128 v1_32_4, v2_32_4;
+  __m128 sum_32_4 = _mm_add_ps(_mm256_extractf128_ps(sum_32_8, 0), _mm256_extractf128_ps(sum_32_8, 1));
+
+  while (pVect1 < pEnd2) {
+    v1_32_4 = _mm_loadu_ps(pVect1);
+    pVect1 += 4;
+    v2_32_4 = _mm_loadu_ps(pVect2);
+    pVect2 += 4;
+    sum_32_4 = _mm_add_ps(sum_32_4, _mm_mul_ps(v1_32_4, v2_32_4));
+  }
+
+  _mm_store_ps(TmpRes, sum_32_4);
+  float sum_32_1 = TmpRes[0] + TmpRes[1] + TmpRes[2] + TmpRes[3];
+  while (pVect1 < pEnd3) {
+    sum_32_1 += (*pVect1) * (*pVect2);
+    ++pVect1;
+    ++pVect2;
+  }
+  return sum_32_1;
+}
+
+#elif defined(PORTABLE_NEON)
+
+inline float L2Sqr16Ext(const float *pVect1, const float *pVect2, size_t &qty, float * __restrict TmpRes) {
+  #pragma message INFO("L2Sqr16Ext: Neon enabled")
+  size_t qty16 = qty >> 4;
+  const float *pEnd1 = pVect1 + (qty16 << 4);
+
+  float32x4_t diff_32_4, v1_32_4, v2_32_4;
+  float32x4_t sum_32_4 = vdupq_n_f32(0);
+
+  while (pVect1 < pEnd1) {
+    PREFETCH((char*)(pVect2 + 16), _MM_HINT_T0);
+    v1_32_4 = vld1q_f32(pVect1);
+    pVect1 += 4;
+    v2_32_4 = vld1q_f32(pVect2);
+    pVect2 += 4;
+    diff_32_4 = vsubq_f32(v1_32_4, v2_32_4);
+    sum_32_4 = vfmaq_f32(sum_32_4, diff_32_4, diff_32_4);
+
+    v1_32_4 = vld1q_f32(pVect1);
+    pVect1 += 4;
+    v2_32_4 = vld1q_f32(pVect2);
+    pVect2 += 4;
+    diff = vsubq_f32(v1_32_4, v2_32_4);
+    sum_32_4 = vfmaq_f32(sum_32_4, diff_32_4, diff_32_4);
+
+    v1_32_4 = vld1q_f32(pVect1);
+    pVect1 += 4;
+    v2_32_4 = vld1q_f32(pVect2);
+    pVect2 += 4;
+    diff_32_4 = vsubq_f32(v1_32_4, v2_32_4);
+    sum_32_4 = vfmaq_f32(sum_32_4, diff_32_4, diff_32_4);
+
+    v1_32_4 = vld1q_f32(pVect1);
+    pVect1 += 4;
+    v2_32_4 = vld1q_f32(pVect2);
+    pVect2 += 4;
+    diff_32_4 = vsubq_f32(v1_32_4, v2_32_4);
+    sum_32_4 = vfmaq_f32(sum_32_4, diff_32_4, diff_32_4);
+  }
+  float32x4_t sum_32_2 = vpaddq_f32(sum_32_4, sum_32_4);
+  return vdups_laneq_f32(sum_32_2, 0) + vdups_laneq_f32(sum_32_2, 1);
+}
+
+inline float L2SqrExt(const float *pVect1, const float *pVect2, size_t &qty, float *__restrict TmpRes) {
+  size_t qty4 = qty >> 2;
+  size_t qty16 = qty >> 4;
+
+  const float *pEnd1 = pVect1 + (qty16 << 4);
+  const float *pEnd2 = pVect1 + (qty4 << 2);
+  const float *pEnd3 = pVect1 + qty;
+
+  float32x4_t diff_32_4, v1_32_4, v2_32_4;
+  float32x4_t sum_32_4 = vdupq_n_f32(0);
+
+  while (pVect1 < pEnd1) {
+    PREFETCH((char*)(pVect2 + 16), _MM_HINT_T0);
+    v1_32_4 = vld1q_f32(pVect1);
+    pVect1 += 4;
+    v2_32_4 = vld1q_f32(pVect2);
+    pVect2 += 4;
+    diff_32_4 = vsubq_f32(v1_32_4, v2_32_4);
+    sum_32_4 = vfmaq_f32(sum_32_4, diff_32_4, diff_32_4);
+
+    v1_32_4 = vld1q_f32(pVect1);
+    pVect1 += 4;
+    v2_32_4 = vld1q_f32(pVect2);
+    pVect2 += 4;
+    diff_32_4 = vsubq_f32(v1_32_4, v2_32_4);
+    sum_32_4 = vfmaq_f32(sum_32_4, diff_32_4, diff_32_4);
+
+    v1_32_4 = vld1q_f32(pVect1);
+    pVect1 += 4;
+    v2_32_4 = vld1q_f32(pVect2);
+    pVect2 += 4;
+    diff_32_4 = vsubq_f32(v1_32_4, v2_32_4);
+    sum_32_4 = vfmaq_f32(sum_32_4, diff_32_4, diff_32_4);
+
+    v1_32_4 = vld1q_f32(pVect1);
+    pVect1 += 4;
+    v2_32_4 = vld1q_f32(pVect2);
+    pVect2 += 4;
+    diff_32_4 = vsubq_f32(v1_32_4, v2_32_4);
+    sum_32_4 = vfmaq_f32(sum_32_4, diff_32_4, diff_32_4);
+  }
+
+  while (pVect1 < pEnd2) {
+    v1_32_4 = vld1q_f32(pVect1);
+    pVect1 += 4;
+    v2_32_4 = vld1q_f32(pVect2);
+    pVect2 += 4;
+    diff_32_4 = vsubq_f32(v1_32_4, v2_32_4);
+    sum_32_4 = vfmaq_f32(sum_32_4, diff_32_4, diff_32_4);
+  }
+
+  float32x4_t sum_32_2 = vpaddq_f32(sum_32_4, sum_32_4);
+  float sum_32_1 = vdups_laneq_f32(sum_32_2, 0) + vdups_laneq_f32(sum_32_2, 1);
+  float diff_32_1;
+  while (pVect1 < pEnd3) {
+    diff_32_1 = *pVect1++ - *pVect2++;
+    sum_32_1 += diff_32_1 * diff_32_1;
+  }
+
+  return sum_32_1;
+}
+
+inline float ScalarProduct(const float *__restrict pVect1, const float *__restrict pVect2, size_t qty,
+                  float *__restrict TmpRes) {
+  #pragma message INFO("ScalarProduct: Neon enabled")
+  size_t qty16 = qty / 16;
+  size_t qty4 = qty / 4;
+
+  const float *pEnd1 = pVect1 + 16 * qty16;
+  const float *pEnd2 = pVect1 + 4 * qty4;
+  const float *pEnd3 = pVect1 + qty;
+
+  float32x4_t v1_32_4, v2_32_4;
+  float32x4_t sum_32_4 = vdupq_n_f32(0);
+
+  while (pVect1 < pEnd1) {
+    PREFETCH((char*)(pVect2 + 16), _MM_HINT_T0);
+    v1_32_4 = vld1q_f32(pVect1);
+    pVect1 += 4;
+    v2_32_4 = vld1q_f32(pVect2);
+    pVect2 += 4;
+    sum_32_4 = vfmaq_f32(sum_32_4, v1_32_4, v2_32_4);
+
+    v1_32_4 = vld1q_f32(pVect1);
+    pVect1 += 4;
+    v2_32_4 = vld1q_f32(pVect2);
+    pVect2 += 4;
+    sum_32_4 = vfmaq_f32(sum_32_4, v1_32_4, v2_32_4);
+
+    v1_32_4 = vld1q_f32(pVect1);
+    pVect1 += 4;
+    v2_32_4 = vld1q_f32(pVect2);
+    pVect2 += 4;
+    sum_32_4 = vfmaq_f32(sum_32_4, v1_32_4, v2_32_4);
+
+    v1_32_4 = vld1q_f32(pVect1);
+    pVect1 += 4;
+    v2_32_4 = vld1q_f32(pVect2);
+    pVect2 += 4;
+    sum_32_4 = vfmaq_f32(sum_32_4, v1_32_4, v2_32_4);
+  }
+
+  while (pVect1 < pEnd2) {
+    v1_32_4 = vld1q_f32(pVect1);
+    pVect1 += 4;
+    v2_32_4 = vld1q_f32(pVect2);
+    pVect2 += 4;
+    sum_32_4 = vfmaq_f32(sum_32_4, v1_32_4, v2_32_4);
+  }
+
+  float32x4_t sum_32_2 = vpaddq_f32(sum_32_4, sum_32_4);
+  float sum_32_1 = vdups_laneq_f32(sum_32_2, 0) + vdups_laneq_f32(sum_32_2, 1);
 
   while (pVect1 < pEnd3) {
-    float diff = *pVect1++ - *pVect2++;
-    res += diff * diff;
+    sum_32_1 += (*pVect1) * (*pVect2);
+    ++pVect1;
+    ++pVect2;
   }
+  return sum_32_1;
+}
 
-  return res;
 #else
-  #pragma message WARN("L2SqrExt: SSE2 is not available")
-  v = L2NormStandard(pVect1, pVect2, qty);
+
+inline float L2SqrExt(const float *pVect1, const float *pVect2, size_t &qty, float *__restrict TmpRes) {
+  #pragma message WARN("L2SqrExt: SIMD is not available")
+  float v = L2NormStandard(pVect1, pVect2, qty);
   return v * v;
-#endif
-};
+}
 
-inline float
-ScalarProductSSE(const float *__restrict pVect1, const float *__restrict pVect2, size_t qty,
+inline float L2Sqr16Ext(const float *pVect1, const float *pVect2, size_t &qty, float * __restrict TmpRes) {
+  return L2SqrExt(pVect1, pVect2, qty, TmpRes);
+}
+
+inline float ScalarProduct(const float *__restrict pVect1, const float *__restrict pVect2, size_t qty,
                   float *__restrict TmpRes) {
-#ifdef PORTABLE_SSE2
-  size_t qty16 = qty / 16;
-  size_t qty4 = qty / 4;
-
-  const float *pEnd1 = pVect1 + 16 * qty16;
-  const float *pEnd2 = pVect1 + 4 * qty4;
-  const float *pEnd3 = pVect1 + qty;
-
-  __m128 v1, v2;
-  __m128 sum_prod = _mm_set1_ps(0);
-
-  while (pVect1 < pEnd1) {
-    v1 = _mm_loadu_ps(pVect1);
-    pVect1 += 4;
-    v2 = _mm_loadu_ps(pVect2);
-    pVect2 += 4;
-    sum_prod = _mm_add_ps(sum_prod, _mm_mul_ps(v1, v2));
-
-    v1 = _mm_loadu_ps(pVect1);
-    pVect1 += 4;
-    v2 = _mm_loadu_ps(pVect2);
-    pVect2 += 4;
-    sum_prod = _mm_add_ps(sum_prod, _mm_mul_ps(v1, v2));
-
-    v1 = _mm_loadu_ps(pVect1);
-    pVect1 += 4;
-    v2 = _mm_loadu_ps(pVect2);
-    pVect2 += 4;
-    sum_prod = _mm_add_ps(sum_prod, _mm_mul_ps(v1, v2));
-
-    v1 = _mm_loadu_ps(pVect1);
-    pVect1 += 4;
-    v2 = _mm_loadu_ps(pVect2);
-    pVect2 += 4;
-    sum_prod = _mm_add_ps(sum_prod, _mm_mul_ps(v1, v2));
-  }
-
-  while (pVect1 < pEnd2) {
-    v1 = _mm_loadu_ps(pVect1);
-    pVect1 += 4;
-    v2 = _mm_loadu_ps(pVect2);
-    pVect2 += 4;
-    sum_prod = _mm_add_ps(sum_prod, _mm_mul_ps(v1, v2));
-  }
-
-  _mm_store_ps(TmpRes, sum_prod);
-  float sum = TmpRes[0] + TmpRes[1] + TmpRes[2] + TmpRes[3];
-  while (pVect1 < pEnd3) {
-    sum += (*pVect1) * (*pVect2);
-    ++pVect1;
-    ++pVect2;
-  }
-  return sum;
-#else
-  #pragma message WARN("ScalarProductSSE: SSE2 is not available")
+  #pragma message WARN("ScalarProduct: SIMD is not available")
   return ScalarProduct(pVect1, pVect2, qty);
-#endif
 }
 
-inline float
-ScalarProductAVX(const float *__restrict pVect1, const float *__restrict pVect2, size_t qty,
-                  float *__restrict TmpRes) {
-#ifdef PORTABLE_AVX
-  size_t qty16 = qty / 16;
-  size_t qty4 = qty / 4;
-
-  const float *pEnd1 = pVect1 + 16 * qty16;
-  const float *pEnd2 = pVect1 + 4 * qty4;
-  const float *pEnd3 = pVect1 + qty;
-
-  __m256 sum256 = _mm256_set1_ps(0);
-
-  while (pVect1 < pEnd1) {
-    //_mm_prefetch((char*)(pVect2 + 16), _MM_HINT_T0);
-
-    __m256 v1 = _mm256_loadu_ps(pVect1);
-    pVect1 += 8;
-    __m256 v2 = _mm256_loadu_ps(pVect2);
-    pVect2 += 8;
-    sum256 = _mm256_add_ps(sum256, _mm256_mul_ps(v1, v2));
-
-    v1 = _mm256_loadu_ps(pVect1);
-    pVect1 += 8;
-    v2 = _mm256_loadu_ps(pVect2);
-    pVect2 += 8;
-    sum256 = _mm256_add_ps(sum256, _mm256_mul_ps(v1, v2));
-  }
-
-  __m128 v1, v2;
-  __m128 sum_prod = _mm_add_ps(_mm256_extractf128_ps(sum256, 0), _mm256_extractf128_ps(sum256, 1));
-
-  while (pVect1 < pEnd2) {
-    v1 = _mm_loadu_ps(pVect1);
-    pVect1 += 4;
-    v2 = _mm_loadu_ps(pVect2);
-    pVect2 += 4;
-    sum_prod = _mm_add_ps(sum_prod, _mm_mul_ps(v1, v2));
-  }
-
-  _mm_store_ps(TmpRes, sum_prod);
-  float sum = TmpRes[0] + TmpRes[1] + TmpRes[2] + TmpRes[3];
-  while (pVect1 < pEnd3) {
-    sum += (*pVect1) * (*pVect2);
-    ++pVect1;
-    ++pVect2;
-  }
-  return sum;
-#else
-  return ScalarProductSSE(pVect1, pVect2, qty, TmpRes);
 #endif
-}
-
-
 }

--- a/similarity_search/include/method/hnsw_distfunc_opt_impl_inline.h
+++ b/similarity_search/include/method/hnsw_distfunc_opt_impl_inline.h
@@ -353,7 +353,7 @@ inline float L2Sqr16Ext(const float *pVect1, const float *pVect2, size_t &qty, f
     pVect1 += 4;
     v2_32_4 = vld1q_f32(pVect2);
     pVect2 += 4;
-    diff = vsubq_f32(v1_32_4, v2_32_4);
+    diff_32_4 = vsubq_f32(v1_32_4, v2_32_4);
     sum_32_4 = vfmaq_f32(sum_32_4, diff_32_4, diff_32_4);
 
     v1_32_4 = vld1q_f32(pVect1);

--- a/similarity_search/include/method/hnsw_distfunc_opt_impl_inline.h
+++ b/similarity_search/include/method/hnsw_distfunc_opt_impl_inline.h
@@ -28,6 +28,7 @@
 
 #include "portable_simd.h"
 #include "portable_intrinsics.h"
+#include "portable_prefetch.h"
 #include "distcomp.h"
 
 namespace similarity {

--- a/similarity_search/include/portable_intrinsics.h
+++ b/similarity_search/include/portable_intrinsics.h
@@ -41,6 +41,10 @@
 #include <portable_simd.h>
 #endif
 
+#if defined(__ARM_NEON)
+#define PORTABLE_NEON
+#endif
+
 #if defined(PORTABLE_SSE4) 
 /*
  * Based on explanations/suggestions from here
@@ -59,3 +63,11 @@
 #endif
 
 
+
+#if defined(__x86_64__) || defined(__i386__)
+#define PREFETCH(a,sel) _mm_prefetch(a, sel)
+#elif defined(__aarch64__)
+#define PREFETCH(a,sel) __builtin_prefetch(a, 0, 0)
+#else
+#define PREFETCH(a,sel) do {} while (0)
+#endif

--- a/similarity_search/include/portable_intrinsics.h
+++ b/similarity_search/include/portable_intrinsics.h
@@ -36,13 +36,12 @@
 #define PORTABLE_AVX2
 #endif
 
+#if defined(__ARM_NEON)
+#define PORTABLE_NEON
+#endif
 
 #if defined(PORTABLE_SSE2)
 #include <portable_simd.h>
-#endif
-
-#if defined(__ARM_NEON)
-#define PORTABLE_NEON
 #endif
 
 #if defined(PORTABLE_SSE4) 
@@ -60,14 +59,4 @@
  * not to use the above MM_EXTRACT_FLOAT (https://github.com/searchivarius/BlogCode/tree/master/2016/bench_sums)
  *
  */
-#endif
-
-
-
-#if defined(__x86_64__) || defined(__i386__)
-#define PREFETCH(a,sel) _mm_prefetch(a, sel)
-#elif defined(__aarch64__)
-#define PREFETCH(a,sel) __builtin_prefetch(a, 0, 0)
-#else
-#define PREFETCH(a,sel) do {} while (0)
 #endif

--- a/similarity_search/include/portable_prefetch.h
+++ b/similarity_search/include/portable_prefetch.h
@@ -14,7 +14,7 @@
  */
 #pragma once
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && (defined(__x86_64__) || defined(__i386__))
 #include <intrin.h>
 #define PREFETCH(a,sel) _mm_prefetch(a, sel)
 #elif defined(__x86_64__) || defined(__i386__)

--- a/similarity_search/include/portable_prefetch.h
+++ b/similarity_search/include/portable_prefetch.h
@@ -1,0 +1,27 @@
+/**
+ * Non-metric Space Library
+ *
+ * Main developers: Bilegsaikhan Naidan, Leonid Boytsov, Yury Malkov, Ben Frederickson, David Novak
+ *
+ * For the complete list of contributors and further details see:
+ * https://github.com/searchivarius/NonMetricSpaceLib
+ *
+ * Copyright (c) 2013-2018
+ *
+ * This code is released under the
+ * Apache License Version 2.0 http://www.apache.org/licenses/.
+ *
+ */
+#pragma once
+
+#if defined(_MSC_VER)
+#include <intrin.h>
+#define PREFETCH(a,sel) _mm_prefetch(a, sel)
+#elif defined(__x86_64__) || defined(__i386__)
+#include <mmintrin.h>
+#define PREFETCH(a,sel) _mm_prefetch(a, sel)
+#elif defined(__GNUC__)
+#define PREFETCH(a,sel) __builtin_prefetch(a, 0, 0)
+#else
+#define PREFETCH(a,sel) do {} while (0)
+#endif

--- a/similarity_search/include/portable_prefetch.h
+++ b/similarity_search/include/portable_prefetch.h
@@ -14,7 +14,7 @@
  */
 #pragma once
 
-#if defined(_MSC_VER) && (defined(__x86_64__) || defined(__i386__))
+#if defined(_MSC_VER) && (defined(_M_IX86) || defined(_M_X64))
 #include <intrin.h>
 #define PREFETCH(a,sel) _mm_prefetch(a, sel)
 #elif defined(__x86_64__) || defined(__i386__)

--- a/similarity_search/include/portable_simd.h
+++ b/similarity_search/include/portable_simd.h
@@ -17,7 +17,7 @@
 #if (defined(__x86_64__) || defined(__i386__))
      /* GCC-compatible compiler, targeting x86/x86-64 */
      #include <x86intrin.h>
-#elif defined(__ARM_NEON__)
+#elif defined(__ARM_NEON)
      /* GCC-compatible compiler, targeting ARM with NEON */
      #include <arm_neon.h>
 #elif defined(__IWMMXT__)

--- a/similarity_search/include/sort_arr_bi.h
+++ b/similarity_search/include/sort_arr_bi.h
@@ -21,9 +21,8 @@
 #include <vector>
 #include <algorithm>
 
-#include <portable_simd.h>
-// This is only for PREFETCH
-#include <portable_intrinsics.h>
+#include "portable_simd.h"
+#include "portable_prefetch.h"
 
 /*
  * This is not a fully functional heap and this is done on purpose.

--- a/similarity_search/include/sort_arr_bi.h
+++ b/similarity_search/include/sort_arr_bi.h
@@ -22,8 +22,8 @@
 #include <algorithm>
 
 #include <portable_simd.h>
-// This is for _mm_prefetch
-#include <mmintrin.h>
+// This is only for PREFETCH
+#include <portable_intrinsics.h>
 
 /*
  * This is not a fully functional heap and this is done on purpose.
@@ -77,7 +77,7 @@ class SortArrBI {
 
   void sort() {
     if (!v_.empty())
-      _mm_prefetch(&v_[0], _MM_HINT_T0);
+      PREFETCH(&v_[0], _MM_HINT_T0);
     std::sort(v_.begin(), v_.begin() + num_elems_);
   }
 
@@ -109,7 +109,7 @@ class SortArrBI {
 
     if (num_elems_ < v_.size()) num_elems_++;
     // curr + 1 <= num_elems_
-    _mm_prefetch((char *)&v_[curr], _MM_HINT_T0);
+    PREFETCH((char *)&v_[curr], _MM_HINT_T0);
 
     if (num_elems_ - (1 + curr) > 0)
       memmove((char *)&v_[curr+1], &v_[curr], (num_elems_ - (1 + curr)) * sizeof(v_[0]));
@@ -181,7 +181,7 @@ class SortArrBI {
       if (d > curr) d = curr;
     }
 
-    _mm_prefetch((char*)&v_[curr], _MM_HINT_T0);
+    PREFETCH((char*)&v_[curr], _MM_HINT_T0);
     if (curr < prev) {
       curr = std::lower_bound(&v_[curr], &v_[prev], Item(key)) - &v_[0];
     }

--- a/similarity_search/src/method/hnsw.cc
+++ b/similarity_search/src/method/hnsw.cc
@@ -26,9 +26,8 @@
 #include <cmath>
 #include <iostream>
 #include <memory>
-// This is only for PREFETCH
-#include <portable_intrinsics.h>
 
+#include "portable_prefetch.h"
 #include "portable_simd.h"
 #include "knnquery.h"
 #include "method/hnsw.h"

--- a/similarity_search/src/method/hnsw_distfunc_opt.cc
+++ b/similarity_search/src/method/hnsw_distfunc_opt.cc
@@ -29,8 +29,8 @@
 #include "ported_boost_progress.h"
 #include "rangequery.h"
 
-// This is only for _mm_prefetch
-#include <mmintrin.h>
+// This is only for PREFETCH
+#include <portable_intrinsics.h>
 #include "space.h"
 
 #include "sort_arr_bi.h"
@@ -72,7 +72,7 @@ namespace similarity {
                 int *data = (int *)(linkLists_[curNodeNum] + (maxM_ + 1) * (i - 1) * sizeof(int));
                 int size = *data;
                 for (int j = 1; j <= size; j++) {
-                    _mm_prefetch(data_level0_memory_ + (*(data + j)) * memoryPerObject_ + offsetData_, _MM_HINT_T0);
+                    PREFETCH(data_level0_memory_ + (*(data + j)) * memoryPerObject_ + offsetData_, _MM_HINT_T0);
                 }
 #ifdef DIST_CALC
                 query->distance_computations_ += size;
@@ -116,15 +116,15 @@ namespace similarity {
             curNodeNum = currEv.element;
             int *data = (int *)(data_level0_memory_ + curNodeNum * memoryPerObject_ + offsetLevel0_);
             int size = *data;
-            _mm_prefetch((char *)(massVisited + *(data + 1)), _MM_HINT_T0);
-            _mm_prefetch((char *)(massVisited + *(data + 1) + 64), _MM_HINT_T0);
-            _mm_prefetch(data_level0_memory_ + (*(data + 1)) * memoryPerObject_ + offsetData_, _MM_HINT_T0);
-            _mm_prefetch((char *)(data + 2), _MM_HINT_T0);
+            PREFETCH((char *)(massVisited + *(data + 1)), _MM_HINT_T0);
+            PREFETCH((char *)(massVisited + *(data + 1) + 64), _MM_HINT_T0);
+            PREFETCH(data_level0_memory_ + (*(data + 1)) * memoryPerObject_ + offsetData_, _MM_HINT_T0);
+            PREFETCH((char *)(data + 2), _MM_HINT_T0);
 
             for (int j = 1; j <= size; j++) {
                 int tnum = *(data + j);
-                _mm_prefetch((char *)(massVisited + *(data + j + 1)), _MM_HINT_T0);
-                _mm_prefetch(data_level0_memory_ + (*(data + j + 1)) * memoryPerObject_ + offsetData_, _MM_HINT_T0);
+                PREFETCH((char *)(massVisited + *(data + j + 1)), _MM_HINT_T0);
+                PREFETCH(data_level0_memory_ + (*(data + j + 1)) * memoryPerObject_ + offsetData_, _MM_HINT_T0);
                 if (!(massVisited[tnum] == currentV)) {
 #ifdef DIST_CALC
                     query->distance_computations_++;
@@ -134,7 +134,7 @@ namespace similarity {
                     dist_t d = (fstdistfunc_(pVectq, (float *)(currObj1 + 16), qty, TmpRes));
                     if (closestDistQueuei.top().getDistance() > d || closestDistQueuei.size() < ef_) {
                         candidateQueuei.emplace(-d, tnum);
-                        _mm_prefetch(data_level0_memory_ + candidateQueuei.top().element * memoryPerObject_ + offsetLevel0_,
+                        PREFETCH(data_level0_memory_ + candidateQueuei.top().element * memoryPerObject_ + offsetLevel0_,
                                      _MM_HINT_T0);
                         // query->CheckAndAddToResult(d, new Object(currObj1));
                         query->CheckAndAddToResult(d, data_rearranged_[tnum]);
@@ -178,7 +178,7 @@ namespace similarity {
                 int *data = (int *)(linkLists_[curNodeNum] + (maxM_ + 1) * (i - 1) * sizeof(int));
                 int size = *data;
                 for (int j = 1; j <= size; j++) {
-                    _mm_prefetch(data_level0_memory_ + (*(data + j)) * memoryPerObject_ + offsetData_, _MM_HINT_T0);
+                    PREFETCH(data_level0_memory_ + (*(data + j)) * memoryPerObject_ + offsetData_, _MM_HINT_T0);
                 }
 #ifdef DIST_CALC
                 query->distance_computations_ += size;
@@ -221,15 +221,15 @@ namespace similarity {
 
             int *data = (int *)(data_level0_memory_ + curNodeNum * memoryPerObject_ + offsetLevel0_);
             int size = *data;
-            _mm_prefetch((char *)(massVisited + *(data + 1)), _MM_HINT_T0);
-            _mm_prefetch((char *)(massVisited + *(data + 1) + 64), _MM_HINT_T0);
-            _mm_prefetch(data_level0_memory_ + (*(data + 1)) * memoryPerObject_ + offsetData_, _MM_HINT_T0);
-            _mm_prefetch((char *)(data + 2), _MM_HINT_T0);
+            PREFETCH((char *)(massVisited + *(data + 1)), _MM_HINT_T0);
+            PREFETCH((char *)(massVisited + *(data + 1) + 64), _MM_HINT_T0);
+            PREFETCH(data_level0_memory_ + (*(data + 1)) * memoryPerObject_ + offsetData_, _MM_HINT_T0);
+            PREFETCH((char *)(data + 2), _MM_HINT_T0);
 
             for (int j = 1; j <= size; j++) {
                 int tnum = *(data + j);
-                _mm_prefetch((char *)(massVisited + *(data + j + 1)), _MM_HINT_T0);
-                _mm_prefetch(data_level0_memory_ + (*(data + j + 1)) * memoryPerObject_ + offsetData_, _MM_HINT_T0);
+                PREFETCH((char *)(massVisited + *(data + j + 1)), _MM_HINT_T0);
+                PREFETCH(data_level0_memory_ + (*(data + j + 1)) * memoryPerObject_ + offsetData_, _MM_HINT_T0);
                 if (!(massVisited[tnum] == currentV)) {
 #ifdef DIST_CALC
                     query->distance_computations_++;
@@ -248,7 +248,7 @@ namespace similarity {
             }
 
             if (itemQty) {
-                _mm_prefetch(const_cast<const char *>(reinterpret_cast<char *>(&itemBuff[0])), _MM_HINT_T0);
+                PREFETCH(const_cast<const char *>(reinterpret_cast<char *>(&itemBuff[0])), _MM_HINT_T0);
                 std::sort(itemBuff.begin(), itemBuff.begin() + itemQty);
 
                 size_t insIndex = 0;
@@ -267,7 +267,7 @@ namespace similarity {
                     }
                 }
                 // because itemQty > 1, there would be at least item in sortedArr
-                _mm_prefetch(data_level0_memory_ + sortedArr.top_item().data * memoryPerObject_ + offsetLevel0_, _MM_HINT_T0);
+                PREFETCH(data_level0_memory_ + sortedArr.top_item().data * memoryPerObject_ + offsetLevel0_, _MM_HINT_T0);
             }
             // To ensure that we either reach the end of the unexplored queue or currElem points to the first unused element
             while (currElem < sortedArr.size() && queueData[currElem].used == true)

--- a/similarity_search/src/method/hnsw_distfunc_opt.cc
+++ b/similarity_search/src/method/hnsw_distfunc_opt.cc
@@ -29,8 +29,7 @@
 #include "ported_boost_progress.h"
 #include "rangequery.h"
 
-// This is only for PREFETCH
-#include <portable_intrinsics.h>
+#include "portable_prefetch.h"
 #include "space.h"
 
 #include "sort_arr_bi.h"

--- a/similarity_search/src/method/pivot_neighb_invindx.cc
+++ b/similarity_search/src/method/pivot_neighb_invindx.cc
@@ -20,9 +20,7 @@
 #include <thread>
 #include <unordered_map>
 
-// This is only for PREFETCH
-#include <portable_intrinsics.h>
-
+#include "portable_prefetch.h"
 #include "portable_simd.h"
 #include "space.h"
 #include "rangequery.h"

--- a/similarity_search/src/method/pivot_neighb_invindx.cc
+++ b/similarity_search/src/method/pivot_neighb_invindx.cc
@@ -20,8 +20,8 @@
 #include <thread>
 #include <unordered_map>
 
-// This is only for _mm_prefetch
-#include <mmintrin.h>
+// This is only for PREFETCH
+#include <portable_intrinsics.h>
 
 #include "portable_simd.h"
 #include "space.h"
@@ -648,9 +648,9 @@ void PivotNeighbInvertedIndex<dist_t>::GenSearch(QueryType* query, size_t K) con
           for (size_t i = 0; i < cand_tmp_qty; ++i) {
             query->CheckAndAddToResult(tmp_cand[i]);
             if (i + 3 < cand_tmp_qty) {
-              _mm_prefetch(tmp_cand[i+1]->buffer(), _MM_HINT_T0);
-              _mm_prefetch(tmp_cand[i+2]->buffer(), _MM_HINT_T0);
-              _mm_prefetch(tmp_cand[i+3]->buffer(), _MM_HINT_T0);
+              PREFETCH(tmp_cand[i+1]->buffer(), _MM_HINT_T0);
+              PREFETCH(tmp_cand[i+2]->buffer(), _MM_HINT_T0);
+              PREFETCH(tmp_cand[i+3]->buffer(), _MM_HINT_T0);
             }
           }
         }
@@ -706,9 +706,9 @@ void PivotNeighbInvertedIndex<dist_t>::GenSearch(QueryType* query, size_t K) con
           for (size_t i = 0; i < cand_tmp_qty; ++i) {
             query->CheckAndAddToResult(tmp_cand[i]);
             if (i + 3 < cand_tmp_qty) {
-              _mm_prefetch(tmp_cand[i+1]->buffer(), _MM_HINT_T0);
-              _mm_prefetch(tmp_cand[i+2]->buffer(), _MM_HINT_T0);
-              _mm_prefetch(tmp_cand[i+3]->buffer(), _MM_HINT_T0);
+              PREFETCH(tmp_cand[i+1]->buffer(), _MM_HINT_T0);
+              PREFETCH(tmp_cand[i+2]->buffer(), _MM_HINT_T0);
+              PREFETCH(tmp_cand[i+3]->buffer(), _MM_HINT_T0);
             }
           }
         }
@@ -753,9 +753,9 @@ void PivotNeighbInvertedIndex<dist_t>::GenSearch(QueryType* query, size_t K) con
           for (size_t i = 0; i < cand_tmp_qty; ++i) {
             query->CheckAndAddToResult(tmp_cand[i]);
             if (i + 3 < cand_tmp_qty) {
-              _mm_prefetch(tmp_cand[i+1]->buffer(), _MM_HINT_T0);
-              _mm_prefetch(tmp_cand[i+2]->buffer(), _MM_HINT_T0);
-              _mm_prefetch(tmp_cand[i+3]->buffer(), _MM_HINT_T0);
+              PREFETCH(tmp_cand[i+1]->buffer(), _MM_HINT_T0);
+              PREFETCH(tmp_cand[i+2]->buffer(), _MM_HINT_T0);
+              PREFETCH(tmp_cand[i+3]->buffer(), _MM_HINT_T0);
             }
           }
         }

--- a/similarity_search/src/method/small_world_rand.cc
+++ b/similarity_search/src/method/small_world_rand.cc
@@ -16,9 +16,8 @@
 #include <memory>
 #include <iostream>
 #include <cstddef>
-// This is only for _mm_prefetch
-#include <mmintrin.h>
-
+// This is only for PREFETCH
+#include <portable_intrinsics.h>
 #if defined(_WIN32) || defined(WIN32)
 #include <intrin.h>
 #endif
@@ -659,10 +658,10 @@ void SmallWorldRand<dist_t>::SearchV1Merge(KNNQuery<dist_t>* query) const {
     ++currElem;
 
     for (MSWNode* neighbor : currNode->getAllFriends()) {
-      _mm_prefetch(reinterpret_cast<const char*>(const_cast<const Object*>(neighbor->getData())), _MM_HINT_T0);
+      PREFETCH(reinterpret_cast<const char*>(const_cast<const Object*>(neighbor->getData())), _MM_HINT_T0);
     }
     for (MSWNode* neighbor : currNode->getAllFriends()) {
-      _mm_prefetch(const_cast<const char*>(neighbor->getData()->data()), _MM_HINT_T0);
+      PREFETCH(const_cast<const char*>(neighbor->getData()->data()), _MM_HINT_T0);
     }
 
     if (currNode->getAllFriends().size() > itemBuff.size())
@@ -687,7 +686,7 @@ void SmallWorldRand<dist_t>::SearchV1Merge(KNNQuery<dist_t>* query) const {
     }
 
     if (itemQty) {
-      _mm_prefetch(const_cast<const char*>(reinterpret_cast<char*>(&itemBuff[0])), _MM_HINT_T0);
+      PREFETCH(const_cast<const char*>(reinterpret_cast<char*>(&itemBuff[0])), _MM_HINT_T0);
       std::sort(itemBuff.begin(), itemBuff.begin() + itemQty);
 
       size_t insIndex=0;
@@ -764,10 +763,10 @@ void SmallWorldRand<dist_t>::SearchOld(KNNQuery<dist_t>* query) const {
     }
 
     for (MSWNode* neighbor : (currEv.getMSWNode())->getAllFriends()) {
-      _mm_prefetch(reinterpret_cast<const char*>(const_cast<const Object*>(neighbor->getData())), _MM_HINT_T0);
+      PREFETCH(reinterpret_cast<const char*>(const_cast<const Object*>(neighbor->getData())), _MM_HINT_T0);
     }
     for (MSWNode* neighbor : (currEv.getMSWNode())->getAllFriends()) {
-      _mm_prefetch(const_cast<const char*>(neighbor->getData()->data()), _MM_HINT_T0);
+      PREFETCH(const_cast<const char*>(neighbor->getData()->data()), _MM_HINT_T0);
     }
 
     const vector<MSWNode*>& neighbor = (currEv.getMSWNode())->getAllFriends();

--- a/similarity_search/src/method/small_world_rand.cc
+++ b/similarity_search/src/method/small_world_rand.cc
@@ -16,8 +16,8 @@
 #include <memory>
 #include <iostream>
 #include <cstddef>
-// This is only for PREFETCH
-#include <portable_intrinsics.h>
+
+#include "portable_prefetch.h"
 #if defined(_WIN32) || defined(WIN32)
 #include <intrin.h>
 #endif

--- a/similarity_search/src/method/vptree.cc
+++ b/similarity_search/src/method/vptree.cc
@@ -19,8 +19,8 @@
 #include <string>
 #include <cmath>
 
-// This is only for _mm_prefetch
-#include <mmintrin.h>
+// This is only for PREFETCH
+#include <portable_intrinsics.h>
 #if defined(_WIN32) || defined(WIN32)
 #include <intrin.h>
 #endif
@@ -253,7 +253,7 @@ void VPTree<dist_t, SearchOracle>::VPNode::GenericSearch(QueryType* query,
     --MaxLeavesToVisit;
 
     if (CacheOptimizedBucket_) {
-      _mm_prefetch(CacheOptimizedBucket_, _MM_HINT_T0);
+      PREFETCH(CacheOptimizedBucket_, _MM_HINT_T0);
     }
 
     for (unsigned i = 0; i < bucket_->size(); ++i) {

--- a/similarity_search/src/method/vptree.cc
+++ b/similarity_search/src/method/vptree.cc
@@ -19,8 +19,7 @@
 #include <string>
 #include <cmath>
 
-// This is only for PREFETCH
-#include <portable_intrinsics.h>
+#include "portable_prefetch.h"
 #if defined(_WIN32) || defined(WIN32)
 #include <intrin.h>
 #endif

--- a/similarity_search/test/test_distfunc.cc
+++ b/similarity_search/test/test_distfunc.cc
@@ -235,7 +235,7 @@ bool TestScalarProductAVXAgree(size_t N, size_t dim, size_t Rep) {
             GenRandVect(pVect2, dim, float(1), float(2), true /* do normalize */);
 
             float val1 = ScalarProduct(pVect1, pVect2, dim);
-            float val2 = ScalarProductAVX(pVect1, pVect2, dim, tmpRes);
+            float val2 = ScalarProduct(pVect1, pVect2, dim, tmpRes);
 
             bool bug = false;
             float diff = fabs(val1 - val2);
@@ -268,7 +268,7 @@ bool TestScalarProductSSEAgree(size_t N, size_t dim, size_t Rep) {
             GenRandVect(pVect2, dim, float(1), float(2), true /* do normalize */);
 
             float val1 = ScalarProduct(pVect1, pVect2, dim);
-            float val2 = ScalarProductSSE(pVect1, pVect2, dim, tmpRes);
+            float val2 = ScalarProduct(pVect1, pVect2, dim, tmpRes);
 
             bool bug = false;
             float diff = fabs(val1 - val2);
@@ -429,7 +429,7 @@ bool TestL2SqrExtSSEAgree(size_t N, size_t dim, size_t Rep) {
 
             float val1 = L2NormStandard(pVect1, pVect2, dim);
             val1 = val1 * val1;
-            float val2 = L2SqrExtSSE(pVect1, pVect2, dim, tmpRes);
+            float val2 = L2SqrExt(pVect1, pVect2, dim, tmpRes);
 
             bool bug = false;
 
@@ -459,7 +459,7 @@ bool TestL2Sqr16ExtAVXAgree(size_t N, size_t dim, size_t Rep) {
 
       float val1 = L2NormStandard(pVect1, pVect2, dim);
       val1 = val1 * val1;
-      float val2 = L2Sqr16ExtAVX(pVect1, pVect2, dim, tmpRes);
+      float val2 = L2Sqr16Ext(pVect1, pVect2, dim, tmpRes);
 
       bool bug = false;
 
@@ -495,7 +495,7 @@ bool TestL2Sqr16ExtSSEAgree(size_t N, size_t dim, size_t Rep) {
 
       float val1 = L2NormStandard(pVect1, pVect2, dim);
       val1 = val1 * val1;
-      float val2 = L2Sqr16ExtSSE(pVect1, pVect2, dim, tmpRes);
+      float val2 = L2Sqr16Ext(pVect1, pVect2, dim, tmpRes);
 
       bool bug = false;
 

--- a/similarity_search/test/test_overlap.cc
+++ b/similarity_search/test/test_overlap.cc
@@ -12,7 +12,6 @@
  * Apache License Version 2.0 http://www.apache.org/licenses/.
  *
  */
-#include <sys/time.h>
 
 #include <logging.h>
 #include <idtype.h>

--- a/similarity_search/test/test_overlap.cc
+++ b/similarity_search/test/test_overlap.cc
@@ -101,10 +101,10 @@ TEST(TestIntersect2Way) {
   EXPECT_EQ(vvIds1.size(), vInterQty.size());
 
   for (size_t i = 0; i < vvIds1.size(); ++i) {
-    size_t qty1 = IntersectSizeScalarFast(&vvIds1[i][0], vvIds1[i].size(), 
-                                          &vvIds2[i][0], vvIds2[i].size());
-    size_t qty2 = IntersectSizeScalarStand(&vvIds1[i][0], vvIds1[i].size(), 
-                                          &vvIds2[i][0], vvIds2[i].size());
+    size_t qty1 = IntersectSizeScalarFast(vvIds1[i].size() ? &vvIds1[i][0] : 0, vvIds1[i].size(),
+                                          vvIds2[i].size() ? &vvIds2[i][0] : 0, vvIds2[i].size());
+    size_t qty2 = IntersectSizeScalarStand(vvIds1[i].size() ? &vvIds1[i][0] : 0, vvIds1[i].size(),
+                                           vvIds2[i].size() ? &vvIds2[i][0] : 0, vvIds2[i].size());
     EXPECT_EQ(qty1, vInterQty[i]);
     EXPECT_EQ(qty2, vInterQty[i]);
 
@@ -220,10 +220,10 @@ TEST(TestOverlapInfoDetailed) {
     if (norm1 > 0) overlap_dotprod_norm /= norm1;
     if (norm2 > 0) overlap_dotprod_norm /= norm2;
 
-    size_t qty1 = IntersectSizeScalarFast(&vIds1[0], vIds1.size(), 
-                                          &vIds2[0], vIds2.size());
-    size_t qty2 = IntersectSizeScalarStand(&vIds1[0], vIds1.size(), 
-                                          &vIds2[0], vIds2.size());
+    size_t qty1 = IntersectSizeScalarFast(vIds1.size() ? &vIds1[0] : 0, vIds1.size(),
+            vIds2.size() ? &vIds2[0] : 0, vIds2.size());
+    size_t qty2 = IntersectSizeScalarStand(vIds1.size() ? &vIds1[0] : 0, vIds1.size(),
+            vIds2.size() ? &vIds2[0] : 0, vIds2.size());
     EXPECT_EQ(qty1, qOverlap);
     EXPECT_EQ(qty2, qOverlap);
 
@@ -235,21 +235,21 @@ TEST(TestOverlapInfoDetailed) {
 
     EXPECT_EQ_EPS(overlap_dotprod_norm, oinfo.overlap_dotprod_norm_, eps);
 
-    EXPECT_EQ_EPS(Sum(&vDiffLeft[0], vDiffLeft.size()), oinfo.diff_sum_left_, eps);
-    EXPECT_EQ_EPS(Mean(&vDiffLeft[0], vDiffLeft.size()), oinfo.diff_mean_left_, eps);
-    EXPECT_EQ_EPS(StdDev(&vDiffLeft[0], vDiffLeft.size()), oinfo.diff_std_left_, eps);
+    EXPECT_EQ_EPS(Sum(vDiffLeft.size() ? &vDiffLeft[0] : 0, vDiffLeft.size()), oinfo.diff_sum_left_, eps);
+    EXPECT_EQ_EPS(Mean(vDiffLeft.size() ? &vDiffLeft[0] : 0, vDiffLeft.size()), oinfo.diff_mean_left_, eps);
+    EXPECT_EQ_EPS(StdDev(vDiffLeft.size() ? &vDiffLeft[0] : 0, vDiffLeft.size()), oinfo.diff_std_left_, eps);
 
-    EXPECT_EQ_EPS(Sum(&vOverlapLeft[0], vOverlapLeft.size()), oinfo.overlap_sum_left_, eps);
-    EXPECT_EQ_EPS(Mean(&vOverlapLeft[0], vOverlapLeft.size()), oinfo.overlap_mean_left_, eps);
-    EXPECT_EQ_EPS(StdDev(&vOverlapLeft[0], vOverlapLeft.size()), oinfo.overlap_std_left_, eps);
+    EXPECT_EQ_EPS(Sum(vOverlapLeft.size() ? &vOverlapLeft[0] : 0, vOverlapLeft.size()), oinfo.overlap_sum_left_, eps);
+    EXPECT_EQ_EPS(Mean(vOverlapLeft.size() ? &vOverlapLeft[0] : 0, vOverlapLeft.size()), oinfo.overlap_mean_left_, eps);
+    EXPECT_EQ_EPS(StdDev(vOverlapLeft.size() ? &vOverlapLeft[0] : 0, vOverlapLeft.size()), oinfo.overlap_std_left_, eps);
 
-    EXPECT_EQ_EPS(Sum(&vDiffRight[0], vDiffRight.size()), oinfo.diff_sum_right_, eps);
-    EXPECT_EQ_EPS(Mean(&vDiffRight[0], vDiffRight.size()), oinfo.diff_mean_right_, eps);
-    EXPECT_EQ_EPS(StdDev(&vDiffRight[0], vDiffRight.size()), oinfo.diff_std_right_, eps);
+    EXPECT_EQ_EPS(Sum(vDiffRight.size() ? &vDiffRight[0] : 0, vDiffRight.size()), oinfo.diff_sum_right_, eps);
+    EXPECT_EQ_EPS(Mean(vDiffRight.size() ? &vDiffRight[0] : 0, vDiffRight.size()), oinfo.diff_mean_right_, eps);
+    EXPECT_EQ_EPS(StdDev(vDiffRight.size() ? &vDiffRight[0] : 0, vDiffRight.size()), oinfo.diff_std_right_, eps);
 
-    EXPECT_EQ_EPS(Sum(&vOverlapRight[0], vOverlapRight.size()), oinfo.overlap_sum_right_, eps);
-    EXPECT_EQ_EPS(Mean(&vOverlapRight[0], vOverlapRight.size()), oinfo.overlap_mean_right_, eps);
-    EXPECT_EQ_EPS(StdDev(&vOverlapRight[0], vOverlapRight.size()), oinfo.overlap_std_right_, eps);
+    EXPECT_EQ_EPS(Sum(vOverlapRight.size() ? &vOverlapRight[0] : 0, vOverlapRight.size()), oinfo.overlap_sum_right_, eps);
+    EXPECT_EQ_EPS(Mean(vOverlapRight.size() ? &vOverlapRight[0] : 0, vOverlapRight.size()), oinfo.overlap_mean_right_, eps);
+    EXPECT_EQ_EPS(StdDev(vOverlapRight.size() ? &vOverlapRight[0] : 0, vOverlapRight.size()), oinfo.overlap_std_right_, eps);
 
   } 
 }
@@ -361,15 +361,15 @@ TEST(TestIntersect3Way) {
 
   
   for (size_t i = 0; i < vvAddIds1.size(); ++i) {
-    size_t qty1 = IntersectSizeScalar3way(&vvAddIds1[i][0], vvAddIds1[i].size(), 
-                                          &vvAddIds2[i][0], vvAddIds2[i].size(),
-                                          &vvAddIds3[i][0], vvAddIds3[i].size());
-    size_t qty2 = IntersectSizeScalar3way(&vvAddIds3[i][0], vvAddIds3[i].size(), 
-                                          &vvAddIds1[i][0], vvAddIds1[i].size(),
-                                          &vvAddIds2[i][0], vvAddIds2[i].size());
-    size_t qty3 = IntersectSizeScalar3way(&vvAddIds3[i][0], vvAddIds3[i].size(), 
-                                          &vvAddIds2[i][0], vvAddIds2[i].size(),
-                                          &vvAddIds1[i][0], vvAddIds1[i].size());
+    size_t qty1 = IntersectSizeScalar3way(vvAddIds1[i].size() ? &vvAddIds1[i][0] : 0, vvAddIds1[i].size(),
+                                          vvAddIds2[i].size() ? &vvAddIds2[i][0] : 0, vvAddIds2[i].size(),
+                                          vvAddIds3[i].size() ? &vvAddIds3[i][0] : 0, vvAddIds3[i].size());
+    size_t qty2 = IntersectSizeScalar3way(vvAddIds3[i].size() ? &vvAddIds3[i][0] : 0, vvAddIds3[i].size(),
+                                          vvAddIds1[i].size() ? &vvAddIds1[i][0] : 0, vvAddIds1[i].size(),
+                                          vvAddIds2[i].size() ? &vvAddIds2[i][0] : 0, vvAddIds2[i].size());
+    size_t qty3 = IntersectSizeScalar3way(vvAddIds3[i].size() ? &vvAddIds3[i][0] : 0, vvAddIds3[i].size(),
+                                          vvAddIds2[i].size() ? &vvAddIds2[i][0] : 0, vvAddIds2[i].size(),
+                                          vvAddIds1[i].size() ? &vvAddIds1[i][0] : 0, vvAddIds1[i].size());
     if (qty1 != vAddInterQty[i] || 
         qty2 != vAddInterQty[i] || 
         qty3 != vAddInterQty[i]) LOG(LIB_INFO) << "Failed test (3-way intersect funcs), index: " << i;

--- a/similarity_search/test/test_some_stat.cc
+++ b/similarity_search/test/test_some_stat.cc
@@ -33,7 +33,7 @@ TEST(TestMean) {
     float sum = 0;
     for (float e : v) sum += e;
 
-    float m = Mean(&v[0], v.size())*v.size();
+    float m = Mean(v.size() ? &v[0] : 0, v.size())*v.size();
 
     EXPECT_FALSE(my_isnan(m)); 
     EXPECT_EQ_EPS(sum, m, 1e-5f);


### PR DESCRIPTION
This PR does some refactoring to add ARM compatibility to the library.

First, I added a `PREFETCH` Macro that maps to the correct prefetch function for the architecture used for compilation. For x86 and x64, it will map to `_mm_prefetch`. For aarch64, it will use gcc's `__builtin_prefetch`. For this, I was following a recommendation in [this post](https://stackoverflow.com/questions/16032202/how-to-use-pld-instruction-in-arm). I think it would be possible to embed assembly, but this seems like it may get a little complex. So, for a first version, I just used `__builtin_prefetch`, but can change if you think another implementation may be better. If the architecture is neither x86 nor aarch64, `PREFETCH` will default to a no-op. After making this change, I was able to compile and run `./release/bunit`.

Second, I refactored `similarity_search/include/method/hnsw_distfunc_opt_impl_inline.h`. Instead of having preprocessor directives inside the functions, I created an implementation of *L2Sqr16Ext*, *L2SqrExt*, *ScalarProduct* for *PORTABLE_SSE2*, *PORTABLE_AVX*, *PORTABLE_NEON*, and a default one for architectures without SIMD support.

Third, I added NEON intrinisics to the *PORTABLE_NEON* functions. For this, I referenced the [ARM Intrinsics guide](https://developer.arm.com/architectures/instruction-sets/simd-isas/neon/intrinsics) and [faiss's ARM support](https://github.com/facebookresearch/faiss/blob/569c855ed0eb93f7b6cef3acdcc7cdd209cf7446/faiss/utils/distances_simd.cpp#L547).

Fourth, I changed a few naming conventions in `similarity_search/include/method/hnsw_distfunc_opt_impl_inline.h` in order to improve readibility with SIMD instructions (at least from my own beginner's perspective).

I ran `./release/bunit` on both a [m5.4xlarge instance](https://aws.amazon.com/ec2/instance-types/m5/) for x86 and [m6g.4xlarge](https://aws.amazon.com/ec2/instance-types/m6/) instance for ARM. Both passed.