### PR TITLE
Add support to build aarch64 wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -92,6 +92,52 @@ matrix:
         - *core_build
         - python3.8-dev
         - python3.8-distutils
+  - os: linux
+    dist: xenial
+    env: PYTHON=3.6
+    arch: arm64
+    services:
+    - docker
+    addons:
+      apt:
+       update: true
+       sources:
+       - deadsnakes
+       - sourceline: 'ppa:ubuntu-toolchain-r/test'
+       packages:
+         - *core_build
+         - python3.6-dev
+  - os: linux
+    dist: xenial
+    env: PYTHON=3.7
+    arch: arm64
+    services:
+    - docker
+    addons:
+      apt:
+       update: true
+       sources:
+       - deadsnakes
+       - sourceline: 'ppa:ubuntu-toolchain-r/test'
+       packages:
+         - *core_build
+         - python3.7-dev
+  - os: linux
+    dist: xenial
+    env: PYTHON=3.8
+    arch: arm64
+    services:
+    - docker
+    addons:
+      apt:
+       update: true
+       sources:
+       - deadsnakes
+       - sourceline: 'ppa:ubuntu-toolchain-r/test'
+       packages:
+         - *core_build
+         - python3.8-dev
+         - python3.8-distutils
   - os: osx
     env: PYTHON=2.7-dev
     osx_image: xcode9.2

--- a/travis/deploy.sh
+++ b/travis/deploy.sh
@@ -3,21 +3,32 @@
 set -x
 git clean -fxd
 git clean -fXd   
-CFLAGS=-msse2
 if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+    arch=`uname -m`
     # manylinux build
     echo "Building manylinux wheels with auditwheel and docker"
-    echo "Ignoring manylinux1_i686"
-    for PLAT in manylinux1_x86_64 manylinux2010_x86_64; do
-        DOCKER_IMAGE=quay.io/pypa/$PLAT
-        if [ "$PLAT" == "manylinux1_i686" ]; then
-            PRE_CMD=linux32
-        else
-            PRE_CMD=""
-        fi
+    echo "Building $arch wheels"
+    if [ "$arch" == "aarch64" ]; then
+        CFLAGS=""
+	PRE_CMD=""
+	PLAT=manylinux2014_aarch64
+	DOCKER_IMAGE=quay.io/pypa/$PLAT
         docker pull $DOCKER_IMAGE
         docker run --rm -v `pwd`:/io -e PLAT=$PLAT -e PYTHON=$PYTHON -e CFLAGS=$CFLAGS $DOCKER_IMAGE $PRE_CMD /io/travis/build-wheels.sh
-    done
+    else
+        CFLAGS=-msse2
+        echo "Ignoring manylinux1_i686"
+        for PLAT in manylinux1_x86_64 manylinux2010_x86_64; do
+            DOCKER_IMAGE=quay.io/pypa/$PLAT
+            if [ "$PLAT" == "manylinux1_i686" ]; then
+                PRE_CMD=linux32
+            else
+                PRE_CMD=""
+            fi
+            docker pull $DOCKER_IMAGE
+            docker run --rm -v `pwd`:/io -e PLAT=$PLAT -e PYTHON=$PYTHON -e CFLAGS=$CFLAGS $DOCKER_IMAGE $PRE_CMD /io/travis/build-wheels.sh
+        done
+    fi
     WHEEL_DIR="wheelhouse"
 else
     # os x build


### PR DESCRIPTION
Travis-CI allows for the creation of aarch64 wheels.

Build: https://travis-ci.com/github/janaknat/nmslib/builds/205780637

There are 8-9 failures when testing hnsw. Any suggestions on how to fix these? A majority of the failures are due to expected=0.99 and calculated=~0.98.

Tagging @jmazanec15 since he added ARM compatibility.