### PR TITLE
Remove eigen3-devel installation

### DIFF
--- a/travis/build-wheels.sh
+++ b/travis/build-wheels.sh
@@ -6,7 +6,6 @@ yum install -y atlas-devel
 # nmslib requirements
 yum install -y gsl-devel
 yum install -y boost-devel
-yum install -y eigen3-devel
 
 OUT_DIR=/io/python_bindings/dist/
 mkdir -p "${OUT_DIR}"


### PR DESCRIPTION
Log from a build for aarch64. It looks similar to x86 builds. I can't see if the upload command was executed for both x86 and aarch64. What do you think @searchivarius ?

https://travis-ci.com/github/janaknat/nmslib/jobs/468330360#L6967