### PR TITLE
Data And Index write into one file even without optimized index

### DIFF
--- a/similarity_search/include/experimentconf.h
+++ b/similarity_search/include/experimentconf.h
@@ -110,6 +110,9 @@ public:
     for (auto it = origQuery_.begin(); it != origQuery_.end(); ++it) {
       delete *it;
     }
+	for (auto it = loaddataobjects_.begin(); it != loaddataobjects_.end(); ++it) {
+	  delete *it;
+    }
   }
 
   void PrintInfo() const;
@@ -126,6 +129,14 @@ public:
   const Space<dist_t>&  GetSpace() const { return space_; }
   Space<dist_t>&  GetSpace() { return space_; }
   const ObjectVector& GetDataObjects() const { return dataobjects_; }
+  void ClearWriteableObjects() {
+      for (auto it = loaddataobjects_.begin(); it != loaddataobjects_.end(); ++it) {
+          if(*it != nullptr)
+          delete *it;
+      }
+      loaddataobjects_.clear();
+  }
+  ObjectVector& GetDataWriteableObjects() { return loaddataobjects_; }
   const ObjectVector& GetQueryObjects() const { return queryobjects_; }
   const typename std::vector<unsigned>& GetKNN() const { return knn_; }
   float GetEPS() const { return eps_; }
@@ -162,6 +173,7 @@ public:
 private:
   Space<dist_t>&    space_;
   ObjectVector      dataobjects_;
+  ObjectVector      loaddataobjects_;
   ObjectVector      queryobjects_;
   ObjectVector      origData_;
   ObjectVector      origQuery_;

--- a/similarity_search/include/index.h
+++ b/similarity_search/include/index.h
@@ -57,8 +57,14 @@ public:
   virtual void SaveIndex(const string& location) {
     throw runtime_error("SaveIndex is not implemented for method: " + StrDesc());
   }
+  virtual void SaveIndex(const string& location,const  ObjectVector* pdata) {
+    throw runtime_error("SaveIndex is not implemented for method: " + StrDesc());
+  }
   // LoadIndex is not necessarily implemented
   virtual void LoadIndex(const string& location) {
+    throw runtime_error("LoadIndex is not implemented for method: " + StrDesc());
+  }
+  virtual void LoadIndex(const string& location, ObjectVector* pdata) {
     throw runtime_error("LoadIndex is not implemented for method: " + StrDesc());
   }
   virtual ~Index() {}

--- a/similarity_search/include/method/hnsw.h
+++ b/similarity_search/include/method/hnsw.h
@@ -454,8 +454,10 @@ namespace similarity {
     template <typename dist_t> class Hnsw : public Index<dist_t> {
     public:
         virtual void SaveIndex(const string &location) override;
+		virtual void SaveIndex(const string &location, const ObjectVector* pdata) override;
 
         virtual void LoadIndex(const string &location) override;
+		virtual void LoadIndex(const string &location, ObjectVector* pdata) override;
 
         Hnsw(bool PrintProgress, const Space<dist_t> &space, const ObjectVector &data);
         void CreateIndex(const AnyParams &IndexParams) override;
@@ -501,7 +503,9 @@ namespace similarity {
         void LoadOptimizedIndex(std::istream& input);
 
         void SaveRegularIndexBin(std::ostream& output);
+        void SaveRegularDataBin(std::ostream& output, const ObjectVector* pdata);
         void LoadRegularIndexBin(std::istream& input);
+        void LoadRegularDataBin(std::istream& input, ObjectVector* pdata);
         void SaveRegularIndexText(std::ostream& output);
         void LoadRegularIndexText(std::istream& input);
 

--- a/similarity_search/test/test_integr_util.h
+++ b/similarity_search/test/test_integr_util.h
@@ -462,19 +462,38 @@ size_t RunTestExper(const vector<MethodTestCase>& vTestCases,
                   "Failed to delete file '" + fullIndexName + "'")
         }
 
-        IndexPtr->SaveIndex(fullIndexName);
+		if(IndexPtr->StrDesc() == "hnsw") {
+			IndexPtr->SaveIndex(fullIndexName, &(config.GetDataObjects()));
+			IndexPtr.reset(
+				MethodFactoryRegistry<dist_t>::Instance().
+				CreateMethod(false /* don't print progress */,
+					methodName,
+					SpaceType, config.GetSpace(), 
+					config.GetDataWriteableObjects())
+			);
 
-        IndexPtr.reset(
-                         MethodFactoryRegistry<dist_t>::Instance().
-                         CreateMethod(false /* don't print progress */,
-                                      methodName,
-                                      SpaceType, config.GetSpace(), 
-                                      config.GetDataObjects())
-                      );
 
-        LOG(LIB_INFO) << "Loading the index" ;
+			LOG(LIB_INFO) << "Loading the index and data" ;
+			config.ClearWriteableObjects();
+        	IndexPtr->LoadIndex(fullIndexName, &(config.GetDataWriteableObjects()));
 
-        IndexPtr->LoadIndex(fullIndexName);
+
+		} else {
+			IndexPtr->SaveIndex(fullIndexName);
+			IndexPtr.reset(
+				MethodFactoryRegistry<dist_t>::Instance().
+				CreateMethod(false /* don't print progress */,
+					methodName,
+					SpaceType, config.GetSpace(), 
+					config.GetDataObjects())
+			);
+
+			LOG(LIB_INFO) << "Loading the index" ;
+
+        	IndexPtr->LoadIndex(fullIndexName);
+		}
+
+
       }
 
       LOG(LIB_INFO) << "==============================================";

--- a/similarity_search/test/test_timer.cc
+++ b/similarity_search/test/test_timer.cc
@@ -22,7 +22,7 @@
 
 namespace similarity {
 
-const unsigned TIMER_ERR_TOL = 200;
+const unsigned TIMER_ERR_TOL = 300;
 
 /*
  * These test is intended to run only on Unix-like systems.


### PR DESCRIPTION
As #467 i ask about make data and index into one file.
I check the code: [WriteObjectVectorBinData](https://github.com/nmslib/nmslib/blob/master/similarity_search/src/space.cc#L90), [ReadObjectVectorFromBinData](https://github.com/nmslib/nmslib/blob/master/similarity_search/src/space.cc#L62) in [space.cc](https://github.com/nmslib/nmslib/blob/master/similarity_search/src/space.cc), may be there is a way to make unoptimized index and data into ONE saved file, just move these code into SaveIndex And LoadIndex. so i create a PR for this.

i run the integration test with skip `skip_optimized_index` which would save the data into one file
i am not sure this is a correct way to do it. Hope to get a reply.