### PR TITLE
Fix import on newer versions of pybind11 (fixes #471)

### DIFF
--- a/python_bindings/nmslib.cc
+++ b/python_bindings/nmslib.cc
@@ -444,7 +444,7 @@ PYBIND11_PLUGIN(nmslib) {
 #endif
   // Log using the python logger, instead of defaults built in here
   py::module logging = py::module::import("logging");
-  py::module nmslibLogger = logging.attr("getLogger")("nmslib");
+  py::object nmslibLogger = logging.attr("getLogger")("nmslib");
   setGlobalLogger(new PythonLogger(nmslibLogger));
 
   initLibrary(0 /* seed */, LIB_LOGCUSTOM, NULL);

--- a/python_bindings/requirements.txt
+++ b/python_bindings/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.10.0
-pybind11<2.6.2
+pybind11>=2.2.3
 sphinx_rtd_theme
 

--- a/python_bindings/setup.py
+++ b/python_bindings/setup.py
@@ -10,7 +10,7 @@ __version__ = '2.1.1'
 if sys.platform.startswith("win") and struct.calcsize("P") * 8 == 32:
     raise RuntimeError("Windows 32-bit is not supported.")
 
-dep_list = ['pybind11<2.6.2', 'psutil']
+dep_list = ['pybind11>=2.2.3', 'psutil']
 dep_list.append("numpy>=1.10.0,<1.17 ; python_version=='2.7'")
 dep_list.append("numpy>=1.10.0 ; python_version>='3.5'")
 


### PR DESCRIPTION
logging.getLogger("nmslib") is not a module, so it can't be assigned to
a py::module.

Revert the changes to pin the pybind11 version.