### PR TITLE
Save/load VPTree instances.

### DIFF
--- a/sample_standalone_app/sample_standalone_app1.cc
+++ b/sample_standalone_app/sample_standalone_app1.cc
@@ -209,10 +209,25 @@ int main(int argc, char* argv[]) {
                                         customSpace,
                                         dataSet);
 
+  Index<float>*   indexVPTreeLoaded =
+                        MethodFactoryRegistry<float>::Instance().
+                                CreateMethod(false /* don't print progress */,
+                                        "vptree",
+                                        "custom",
+                                        customSpace,
+                                        dataSet);
+
   indexVPTree->CreateIndex(IndexParams);
   indexVPTree->SetQueryTimeParams(QueryTimeParams);
 
   cout << "VP-tree index is created!" << endl;
+
+  cout << "Saving VP-tree index to file (vptree.dat)." << endl;
+  indexVPTree->SaveIndex("vptree.dat");
+
+  cout << "Loading VP-tree index from file (vptree.dat)." << endl;
+  indexVPTreeLoaded->LoadIndex("vptree.dat");
+  indexVPTreeLoaded->SetQueryTimeParams(QueryTimeParams);
 
   IndexParams= AnyParams({ "projDim=16",   // Projection dimensionality
                            "projType=perm", // using permutations => the number of pivots is equal to projDim and should be < #of objects
@@ -232,6 +247,9 @@ int main(int argc, char* argv[]) {
   doSearch(indexSmallWorld, &knnQ, REP_QTY);
 
   doSearch(indexVPTree, &knnQ, REP_QTY);
+
+  cout << "Searching in loaded VP tree" << endl;
+  doSearch(indexVPTreeLoaded, &knnQ, REP_QTY);
 
   cout << "Saving vectors to a file: " << endl;
 

--- a/similarity_search/include/method/vptree.h
+++ b/similarity_search/include/method/vptree.h
@@ -49,6 +49,9 @@ class VPTree : public Index<dist_t> {
 
   const std::string StrDesc() const override;
 
+  void SaveIndex(const string& location) override;
+  void LoadIndex(const string& location) override;
+
   void Search(RangeQuery<dist_t>* query, IdType) const override;
   void Search(KNNQuery<dist_t>* query, IdType) const override;
 
@@ -72,6 +75,7 @@ class VPTree : public Index<dist_t> {
     // We want trees to be balanced
     const size_t BalanceConst = 4; 
 
+    VPNode(const SearchOracle& oracle);
     VPNode(unsigned level,
            ProgressDisplay* progress_bar,
            const SearchOracle&  oracle,
@@ -87,6 +91,7 @@ class VPTree : public Index<dist_t> {
    private:
     void CreateBucket(bool ChunkBucket, const ObjectVector& data, 
                       ProgressDisplay* progress_bar);
+
     const SearchOracle& oracle_; // The search oracle must be accessed by reference,
                                  // so that VP-tree may be able to change its parameters
     const Object* pivot_;
@@ -116,6 +121,9 @@ class VPTree : public Index<dist_t> {
   bool                ChunkBucket_;
 
   vector<string>  QueryTimeParams_;
+
+  VPNode* LoadNodeData(std::ifstream& input) const;
+  void    SaveNodeData(std::ofstream& output, const VPNode* node) const;
 
   // disable copy and assign
   DISABLE_COPY_AND_ASSIGN(VPTree);

--- a/similarity_search/src/method/vptree.cc
+++ b/similarity_search/src/method/vptree.cc
@@ -182,7 +182,7 @@ template <typename dist_t, typename SearchOracle>
 void
 VPTree<dist_t, SearchOracle>::SaveNodeData(
   std::ofstream& output,
-  const VPTree<dist_t, SearchOracle>::VPNode* node) const {
+  const typename VPTree<dist_t, SearchOracle>::VPNode* node) const {
 
   // Nodes are written to output in pre-order. If a node doesn't have a left/right
   // child, a sentinel value of -1.0 is written instead. Regular nodes are

--- a/similarity_search/src/method/vptree.cc
+++ b/similarity_search/src/method/vptree.cc
@@ -13,6 +13,7 @@
  *
  */
 #include <algorithm>
+#include <iomanip>
 #include <iostream>
 #include <fstream>
 #include <sstream>
@@ -121,6 +122,142 @@ void VPTree<dist_t, SearchOracle>::Search(KNNQuery<dist_t>* query, IdType) const
 }
 
 template <typename dist_t, typename SearchOracle>
+void VPTree<dist_t, SearchOracle>::SaveIndex(const std::string& location) {
+
+  std::ofstream output(location, std::ios::binary);
+  CHECK_MSG(output, "Cannot open file '" + location + "' for writing");
+  output.exceptions(ios::badbit | ios::failbit);
+
+  // Save version number
+  const uint32_t version = 1;
+  writeBinaryPOD(output, version);
+
+  // Save dataset size, so that we can compare with dataset size upon loading
+  writeBinaryPOD(output, this->data_.size());
+
+  // Save tree parameters
+  writeBinaryPOD(output, max_pivot_select_attempts_);
+  writeBinaryPOD(output, BucketSize_);
+  writeBinaryPOD(output, ChunkBucket_);
+  writeBinaryPOD(output, use_random_center_);
+
+  // Save node data
+  if (root_) {
+    SaveNodeData(output, root_.get());
+  }
+}
+
+template <typename dist_t, typename SearchOracle>
+void VPTree<dist_t, SearchOracle>::LoadIndex(const std::string& location) {
+
+  std::ifstream input(location, std::ios::binary);
+  CHECK_MSG(input, "Cannot open file '" + location + "' for reading");
+  input.exceptions(ios::badbit | ios::failbit);
+
+  uint32_t version;
+  readBinaryPOD(input, version);
+  if (version != 1) {
+    PREPARE_RUNTIME_ERR(err) << "File version number (" << version << ") differs from "
+                             << "expected version (1)";
+    THROW_RUNTIME_ERR(err);
+  }
+
+  size_t datasize;
+  readBinaryPOD(input, datasize);
+  if (datasize != this->data_.size()) {
+    PREPARE_RUNTIME_ERR(err) << "Saved dataset size (" << datasize
+                             << ") differs from actual size (" << this->data_.size() << ")";
+    THROW_RUNTIME_ERR(err);
+  }
+
+  readBinaryPOD(input, max_pivot_select_attempts_);
+  readBinaryPOD(input, BucketSize_);
+  readBinaryPOD(input, ChunkBucket_);
+  readBinaryPOD(input, use_random_center_);
+
+  root_ = std::unique_ptr<VPNode>(LoadNodeData(input));
+}
+
+template <typename dist_t, typename SearchOracle>
+void
+VPTree<dist_t, SearchOracle>::SaveNodeData(
+  std::ofstream& output,
+  const VPTree<dist_t, SearchOracle>::VPNode* node) const {
+
+  // Nodes are written to output in pre-order. If a node doesn't have a left/right
+  // child, a sentinel value of -1.0 is written instead. Regular nodes are
+  // serialized in the following order:
+  //
+  // * mediandist (always non-negative)
+  // * number of bucket elements or 0 if not a leaf node (pivot)
+  // * IDs of bucket data, or ID of pivot
+  // * left child tree
+  // * right child tree
+
+  if (node == nullptr) {
+    // write sentinel
+    writeBinaryPOD(output, static_cast<float>(-1.0));
+
+    return;
+  }
+
+  writeBinaryPOD(output, node->mediandist_);
+
+  if (node->bucket_) {
+    writeBinaryPOD(output, node->bucket_->size());
+    for (const auto& element : *(node->bucket_)) {
+      writeBinaryPOD(output, element->id());
+    }
+  } else if (node->pivot_) {
+    size_t bucketsize = 0;
+    writeBinaryPOD(output, bucketsize);
+    writeBinaryPOD(output, node->pivot_->id());
+  }
+
+  SaveNodeData(output, node->left_child_);
+  SaveNodeData(output, node->right_child_);
+}
+
+template <typename dist_t, typename SearchOracle>
+typename VPTree<dist_t, SearchOracle>::VPNode*
+VPTree<dist_t, SearchOracle>::LoadNodeData(std::ifstream& input) const {
+
+  float mediandist;
+
+  readBinaryPOD(input, mediandist);
+  if (mediandist < 0) {
+    // sentinel node
+    return nullptr;
+  }
+
+  VPNode* node = new VPNode(oracle_);
+  node->mediandist_ = mediandist;
+
+  size_t bucketsize;
+  readBinaryPOD(input, bucketsize);
+
+  IdType dataId = 0;
+  if (bucketsize == 0) {
+    // read one element, the pivot
+    readBinaryPOD(input, dataId);
+    node->pivot_ = this->data_[dataId];
+  } else {
+    // read bucket content
+    ObjectVector bucket(bucketsize);
+    for (size_t i = 0; i < bucketsize; i++) {
+      readBinaryPOD(input, dataId);
+      bucket[i] = this->data_[dataId];
+    }
+    node->CreateBucket(false, bucket, nullptr);
+  }
+
+  node->left_child_ = LoadNodeData(input);
+  node->right_child_ = LoadNodeData(input);
+
+  return node;
+}
+
+template <typename dist_t, typename SearchOracle>
 void VPTree<dist_t, SearchOracle>::VPNode::CreateBucket(bool ChunkBucket, 
                                                         const ObjectVector& data, 
                                                         ProgressDisplay* progress_bar) {
@@ -131,6 +268,16 @@ void VPTree<dist_t, SearchOracle>::VPNode::CreateBucket(bool ChunkBucket,
     }
     if (progress_bar) (*progress_bar) += data.size();
 }
+
+template <typename dist_t, typename SearchOracle>
+VPTree<dist_t, SearchOracle>::VPNode::VPNode(const SearchOracle& oracle)
+    : oracle_(oracle),
+      pivot_(NULL),
+      mediandist_(0),
+      left_child_(NULL),
+      right_child_(NULL),
+      bucket_(NULL),
+      CacheOptimizedBucket_(NULL) {}
 
 template <typename dist_t, typename SearchOracle>
 VPTree<dist_t, SearchOracle>::VPNode::VPNode(


### PR DESCRIPTION
Implements `VPTree::SaveIndex` and `VPTree::LoadIndex`.

Some implementation nodes: 

1. Nodes are saved in pre-order traversal order. This is implemented recursively, since the tree is never very deep (and the original construction of the tree happens recursively, too). I had originally used a non-recursive implementation but this was much more complicated because of the presence of sentinel nodes (see below).
2. Some nodes have 0 or 1 children. To distinguish between either case we write a sentinel value (-1.0) to file in case a child is NULL. Regular node data is serialized starting with the median distance (which is non-negative), so that upon loading we can check the first float value present, and distinguish between a NULL child and a regular child.

I am not a routined C++ programmer so any comments and improvements are welcome.

I would like to write a test for this functionality, but haven't looked at the available tests yet. 