### PR TITLE
More accurate approach to whether Mac is using ARM

### DIFF
--- a/python_bindings/setup.py
+++ b/python_bindings/setup.py
@@ -5,6 +5,7 @@ import sys
 import setuptools
 import struct
 import platform
+import re
 
 __version__ = '2.1.2'
 
@@ -130,7 +131,7 @@ class BuildExt(build_ext):
     }
 
     if sys.platform == 'darwin':
-        if platform.processor() in ('arm64', 'arm'):
+        if re.search('ARM64', platform.uname().version):
             c_opts['unix'].remove('-march=native')
             # thanks to @https://github.com/drkeoni
             # https://github.com/nmslib/nmslib/issues/476#issuecomment-876094529

--- a/similarity_search/src/distcomp_scalar.cc
+++ b/similarity_search/src/distcomp_scalar.cc
@@ -82,7 +82,7 @@ template float  QueryNormScalarProduct<float>(const float* pVect1, const float* 
 template <>
 float NormScalarProductSIMD(const float* pVect1, const float* pVect2, size_t qty) {
 #ifndef PORTABLE_SSE2
-#pragma message WARN("ScalarProductSIMD<float>: SSE2 is not available, defaulting to pure C++ implementation!")
+#pragma message ("ScalarProductSIMD<float>: SSE2 is not available, defaulting to pure C++ implementation!")
     return NormScalarProduct(pVect1, pVect2, qty);
 #else
     size_t qty16  = qty/16;
@@ -192,7 +192,7 @@ template float  ScalarProduct<float>(const float* pVect1, const float* pVect2, s
 template <>
 float ScalarProductSIMD(const float* pVect1, const float* pVect2, size_t qty) {
 #ifndef PORTABLE_SSE2
-#pragma message WARN("ScalarProductSIMD<float>: SSE2 is not available, defaulting to pure C++ implementation!")
+#pragma message ("ScalarProductSIMD<float>: SSE2 is not available, defaulting to pure C++ implementation!")
     return ScalarProduct(pVect1, pVect2, qty);
 #else
     size_t qty16  = qty/16;


### PR DESCRIPTION
On a Mac architecture, `platform.processor` may return `i386` even when `ARM` is in use.  The code below should be more accurate.  See https://stackoverflow.com/questions/7491391/is-there-a-reliable-way-to-determine-the-system-cpu-architecture-using-python#comment122392526_7491483 and additional comments for some more information.

I was personally running into this problem and the following fix solved it for me.