### PR TITLE
optinal disabling  sync_with_stdio 

### DIFF
--- a/similarity_search/src/init.cc
+++ b/similarity_search/src/init.cc
@@ -34,10 +34,10 @@ namespace similarity {
 int                                                 defaultRandomSeed = 0;
 thread_local std::unique_ptr<RandomGeneratorType>   randomGen;
 
-void initLibrary(int seed, LogChoice choice, const char* pLogFile) {
+void initLibrary(int seed, LogChoice choice, const char* pLogFile, bool syncWithStdIO = false) {
   defaultRandomSeed = seed;
 
-  std::ios_base::sync_with_stdio(false);
+  std::ios_base::sync_with_stdio(syncWithStdIO);
   InitializeLogger(choice, pLogFile);
   initSpaces();
   initMethods();


### PR DESCRIPTION
disabling sync_with_stdio by default  create very destructive side effects. make it optional