### PR TITLE
Update setup.py

### DIFF
--- a/python_bindings/setup.py
+++ b/python_bindings/setup.py
@@ -14,7 +14,7 @@ if sys.platform.startswith("win") and struct.calcsize("P") * 8 == 32:
 dep_list = ['pybind11>=2.2.3', 'psutil']
 dep_list.append("numpy>=1.10.0 ; python_version>='3.5'")
 
-py_version = tuple([int(s) for s in platform.python_version().split('.')])[0:2]
+py_version = tuple([int(s.split('rc')[0]) if 'rc' in s else int(s) for s in platform.python_version().split('.')])[0:2]
 if py_version != (2, 7) and py_version < (3, 5):
     raise RuntimeError("Python version 2.7 or >=3.5 required.")
 


### PR DESCRIPTION
Line 17: Extend python version to include the release candidate format (e.g. 3.11.0rc1) in addition to the stable release format (e.g. 3.11.0)